### PR TITLE
fix(csp): allow TS API staging URL in connect-src

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       style-src 'self' 'unsafe-inline';
       img-src 'self' data: blob: https:;
       font-src 'self';
-      connect-src 'self' https://*.mapbox.com https://api.pdok.nl https://*.fundermaps.com https://*.digitaloceanspaces.com https://*.amazonaws.com;
+      connect-src 'self' https://*.mapbox.com https://api.pdok.nl https://*.fundermaps.com https://*.digitaloceanspaces.com https://*.amazonaws.com https://fundermaps-api-test-grcaa.ondigitalocean.app;
       worker-src 'self' blob:;
       child-src blob:;
       base-uri 'self';


### PR DESCRIPTION
## Summary
The TS API at \`https://fundermaps-api-test-grcaa.ondigitalocean.app\` was being blocked by the connect-src directive (only \`*.fundermaps.com\` is allowlisted). Adding it explicitly so the cutover (PR #192) can be tested in the browser.

## TODO
Remove this entry once the TS API gets a fundermaps.com subdomain (e.g. \`api-test.fundermaps.com\`) — \`*.fundermaps.com\` will then cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)