### PR TITLE
fix(mapset): handle TS API snake_case layerset jsonb field

### DIFF
--- a/src/services/api/mapset.ts
+++ b/src/services/api/mapset.ts
@@ -1,36 +1,46 @@
-import { type IMapsetFE, type IMapset } from "@/datastructures/interfaces"
+import { type IMapsetFE, type IMapset, type IMapsetLayer } from "@/datastructures/interfaces"
 import { get } from "../apiClient"
 
-const mapMapset = (rawmapset: IMapset): IMapsetFE => {
-  let metadata = {}
-  let layerSet = []
-
-  try {
-    layerSet = rawmapset.layerSet ? JSON.parse(rawmapset.layerSet) : []
-  } catch {
-    console.warn(`Failed to process layerSet for mapset "${rawmapset?.name || rawmapset.id}"`)
+// TS API returns mapset rows as raw PG: snake_case `layerset` (jsonb, already
+// parsed to array) and `metadata` (jsonb, already parsed to object). The
+// older C# WebApi returned `layerSet` (camelCase) as JSON-encoded strings.
+// Read both to stay tolerant during the cutover; drop the C# fallbacks
+// once the API is the only source.
+const mapMapset = (raw: IMapset & { layerset?: unknown }): IMapsetFE => {
+  const layerSetRaw = (raw as { layerset?: unknown }).layerset ?? raw.layerSet
+  let layerSet: unknown[] = []
+  if (Array.isArray(layerSetRaw)) {
+    layerSet = layerSetRaw
+  } else if (typeof layerSetRaw === 'string') {
+    try { layerSet = JSON.parse(layerSetRaw) } catch {
+      console.warn(`Failed to parse layerSet string for mapset "${raw?.name || raw.id}"`)
+    }
   }
 
-  try {
-    metadata = rawmapset?.metadata ? JSON.parse(rawmapset.metadata) : {}
-  } catch {
-    console.warn('Failed to process mapset metadata')
+  const metadataRaw = raw?.metadata
+  let metadata: object = {}
+  if (metadataRaw && typeof metadataRaw === 'object') {
+    metadata = metadataRaw as object
+  } else if (typeof metadataRaw === 'string') {
+    try { metadata = JSON.parse(metadataRaw) } catch {
+      console.warn(`Failed to parse metadata string for mapset "${raw?.name || raw.id}"`)
+    }
   }
 
   return {
-    id: rawmapset.id,
-    slug: rawmapset.slug,
-    name: rawmapset?.name || 'Onbekende laag',
-    style: rawmapset.style,
+    id: raw.id,
+    slug: raw.slug,
+    name: raw?.name || 'Onbekende laag',
+    style: raw.style,
     metadata,
-    public: (!!rawmapset?.public) || false,
-    consent: rawmapset?.consent || null,
-    note: rawmapset?.note || null,
-    icon: rawmapset?.icon || 'home-info',
-    fenceNeighborhood: rawmapset?.fenceNeighborhood || [],
-    fenceDistrict: rawmapset?.fenceDistrict || [],
-    fenceMunicipality: rawmapset?.fenceMunicipality || [],
-    layerSet,
+    public: (!!raw?.public) || false,
+    consent: raw?.consent || null,
+    note: raw?.note || null,
+    icon: raw?.icon || 'home-info',
+    fenceNeighborhood: raw?.fenceNeighborhood || [],
+    fenceDistrict: raw?.fenceDistrict || [],
+    fenceMunicipality: raw?.fenceMunicipality || [],
+    layerSet: layerSet as IMapsetLayer[],
     loadedAt: Date.now()
   }
 }


### PR DESCRIPTION
## Summary
TS API returns mapset rows with \`layerset\` (lowercase, jsonb already-parsed array) and \`metadata\` (jsonb already-parsed object). The old C# WebApi returned \`layerSet\` (camelCase JSON-encoded string) and \`metadata\` (string). Without this fix every mapset's layerSet ended up empty → no layers rendered, no buildings visible on the map.

The adapter now reads both shapes (snake-jsonb-array OR camel-string-encoded). The C# fallback can be dropped once the old WebApi is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)