### PR TITLE
fix(mapset): read snake_case fence_* arrays from TS API

### DIFF
--- a/src/services/api/mapset.ts
+++ b/src/services/api/mapset.ts
@@ -37,9 +37,9 @@ const mapMapset = (raw: IMapset & { layerset?: unknown }): IMapsetFE => {
     consent: raw?.consent || null,
     note: raw?.note || null,
     icon: raw?.icon || 'home-info',
-    fenceNeighborhood: raw?.fenceNeighborhood || [],
-    fenceDistrict: raw?.fenceDistrict || [],
-    fenceMunicipality: raw?.fenceMunicipality || [],
+    fenceNeighborhood: (raw as { fence_neighborhood?: string[] | null }).fence_neighborhood ?? raw?.fenceNeighborhood ?? [],
+    fenceDistrict: (raw as { fence_district?: string[] | null }).fence_district ?? raw?.fenceDistrict ?? [],
+    fenceMunicipality: (raw as { fence_municipality?: string[] | null }).fence_municipality ?? raw?.fenceMunicipality ?? [],
     layerSet: layerSet as IMapsetLayer[],
     loadedAt: Date.now()
   }


### PR DESCRIPTION
## Summary
Companion to FunderMapsApi PR #14. The TS API now returns the org geofence as \`fence_neighborhood\`, \`fence_district\`, \`fence_municipality\` (snake_case). The mapset adapter reads those first; falls back to the C# camelCase shape so nothing breaks during deploy ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)