### PR TITLE
fix(metadata): refetch on every auth transition, not just app mount

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,17 +1,27 @@
 <script setup lang="ts">
-import { onBeforeMount } from 'vue';
+import { watch } from 'vue';
+import { storeToRefs } from 'pinia';
 import { useSessionStore } from '@/store/session';
 import { useMetadataStore } from '@/store/metadata'
 
 const sessionStore = useSessionStore()
-const { retrieve: retrieveUserMetaData } = useMetadataStore()
+const metadataStore = useMetadataStore()
+const { isAuthenticated } = storeToRefs(sessionStore)
 
 sessionStore.authenticateFromAccessToken()
 
-onBeforeMount(async () => {
-  await retrieveUserMetaData()
-})
-
+// Refetch metadata whenever the user becomes authenticated. Covers three
+// cases: fresh login (false -> true), session restore on page load
+// (false -> true once /me resolves), and re-login after a logout. The
+// initial false state for guest users also runs once with `immediate: true`
+// so isAvailable flips on for the guest path.
+watch(
+  isAuthenticated,
+  async () => {
+    await metadataStore.retrieve()
+  },
+  { immediate: true }
+)
 </script>
 
 <template>


### PR DESCRIPTION
retrieveUserMetaData was only called in onBeforeMount, so metadata never reloaded after logout + login (App.vue stays mounted across the auth flow). On a fresh login, the mount callback ran while isAuthenticated was still false and silently took the guest branch — leaving the map at its Amsterdam default until the next page reload.

Replace the onBeforeMount with a watch on isAuthenticated. Fires for:
- guest mount (immediate: true, isAvailable flips true for the localStorage path)
- session restore (false -> true once /me resolves)
- fresh login (false -> true after sign-in)
- re-login after logout (false -> true again)