### PR TITLE
fix(auth+map): logout/re-login races and stale username

### DIFF
--- a/src/components/Mapbox/Map.vue
+++ b/src/components/Mapbox/Map.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, shallowRef } from 'vue';
+import { computed, onBeforeUnmount, shallowRef, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import MapBox from '@/components/Common/Mapbox/MapBox.vue';
@@ -22,7 +22,8 @@ import { useMetadataStore } from '@/store/metadata';
 
 const { isLeftSidebarOpen } = storeToRefs( useMainStore() )
 const { hasSelectedBuilding } = storeToRefs(useBuildingStore())
-const { isAvailable: hasUserMetaData } = storeToRefs(useMetadataStore())
+const metadataStore = useMetadataStore()
+const { isAvailable: hasUserMetaData, metadata: userMetadata } = storeToRefs(metadataStore)
 
 const emit = defineEmits<{ ready: [] }>()
 
@@ -79,6 +80,30 @@ const onLoad = function onLoad({ map }: { map: Map }) {
 
   emit('ready')
 }
+
+/**
+ * After login, the metadata store refetches and the user's saved
+ * lastCenterPosition / zoom / pitch / bearing are reloaded — but the map
+ * was already mounted with the pre-login values, so we re-center it here.
+ * Only fires when the *center* changes from non-empty to a different value
+ * (avoids fighting our own moveend writes during normal panning).
+ */
+let lastAppliedCenterKey: string | null = null
+watch(
+  () => userMetadata.value?.lastCenterPosition as { lng: number; lat: number } | undefined,
+  (center) => {
+    if (!mapInstance.value || !center) return
+    const key = `${center.lng},${center.lat}`
+    if (key === lastAppliedCenterKey) return
+    lastAppliedCenterKey = key
+    mapInstance.value.jumpTo({
+      center: [center.lng, center.lat],
+      zoom: parseFloat(userMetadata.value?.lastZoomLevel as string) || mapInstance.value.getZoom(),
+      pitch: parseFloat(userMetadata.value?.lastPitchDegree as string) || mapInstance.value.getPitch(),
+      bearing: parseFloat(userMetadata.value?.lastRotation as string) || mapInstance.value.getBearing(),
+    })
+  },
+)
 
 /**
  * Cleanup event handlers

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { vOnClickOutside } from '@vueuse/components'
 
@@ -26,7 +26,9 @@ const { isAuthenticated, currentUser } = storeToRefs( sessionStore )
  * Component related data
  */
 const isOpen = ref(false)
-const userName = currentUser.value?.name || 'Onbekend'
+// Reactive: currentUser is null at component mount (set after /me resolves
+// or after a re-login), so capturing once would freeze the avatar label.
+const userName = computed(() => currentUser.value?.name || 'Onbekend')
 
 /**
  * Open & close the menu

--- a/src/store/metadata.ts
+++ b/src/store/metadata.ts
@@ -133,15 +133,15 @@ export const useMetadataStore = defineStore('metadata', () => {
   };
 
   /**
-   * Clears all metadata.
-   * Resets the in-memory `metadataState` to an empty object.
-   * If the user is authenticated, it triggers a debounced call to `storeToApi` to persist
-   * the cleared state to the backend.
-   * @returns {void}
+   * Clears the in-memory metadata. Does NOT push the cleared state to the
+   * server — server-side metadata is meant to persist across sessions.
+   * Calling storeToApi() here was the source of a race: logout schedules a
+   * debounced PUT, the user re-logs in inside 500ms, /me's GET races the
+   * debounced PUT, and depending on timing the empty {} can land on the
+   * server and wipe the user's saved map position.
    */
   const clear = (): void => {
     metadataState.value = {};
-    storeToApi();
   };
 
   return {

--- a/src/store/session.ts
+++ b/src/store/session.ts
@@ -74,9 +74,14 @@ export const useSessionStore = defineStore('session', () => {
   };
 
   /**
-   * Log out: clear token, user state, and dependent stores.
+   * Log out: invalidate server session (best-effort), clear token + user
+   * state, and clear dependent stores.
    */
-  const logout = (): void => {
+  const logout = async (): Promise<void> => {
+    // Server-side invalidation is best-effort — if it fails (network error,
+    // expired session) we still want to log out client-side.
+    try { await api.auth.signOut(); } catch { /* swallow */ }
+
     removeAccessToken();
     currentUser.value = null;
 


### PR DESCRIPTION
## Summary
Four targeted fixes for the login/logout flakiness:

1. **\`metadata.clear()\` no longer pushes empty state to the server.** Logout -> clear() -> debounced storeToApi (500ms). If the user re-logged in inside that window AND /me's metadata GET was still in flight when the debounce fired, the empty \`{}\` landed on the server and wiped the saved map position. Server-side metadata persists across sessions; clearing local state is enough.

2. **\`session.logout()\` now calls \`api.auth.signOut()\`** (best-effort). The server-side bearer token was previously left valid until the cleanup job swept it.

3. **\`Map.vue\` watches \`userMetadata.lastCenterPosition\`** and \`jumpTo\`'s the new coords when metadata refreshes after the map is already mounted (i.e. after sign-in). Previously the map mounted once with pre-login defaults — \`options\` recomputed but Mapbox doesn't re-init. Tracks the last-applied center to avoid fighting our own \`moveend\` writes.

4. **\`UserMenu.userName\` is now a computed** instead of being captured once at setup. Without this the avatar label froze as 'Onbekend' if the component mounted before /me resolved (or after a re-login).

These are surgical fixes for the reported symptoms. The broader auth-layer simplification (drop optimistic restore, derive isAuthenticated from token presence, push store cleanup into watches instead of explicit chain) is still worth doing — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)