### PR TITLE
ui: unified Statistieken report, chart legibility, header trim

### DIFF
--- a/src/components/Building/StatisticsPanel.vue
+++ b/src/components/Building/StatisticsPanel.vue
@@ -14,7 +14,7 @@ import { useStatisticsStore } from '@/store/building/statistics';
 
 import { useBuildingStore } from '@/store/buildings';
 const statisticsStore = useStatisticsStore()
-const { showStatisticsModal, statisticsGraph } = storeToRefs(statisticsStore)
+const { showStatisticsModal, scrollToSection } = storeToRefs(statisticsStore)
 const { buildingId } = storeToRefs(useBuildingStore())
 
 /**
@@ -40,10 +40,10 @@ const noTotalReportCount = computed(() => {
 
 
 /**
- * Open the statistics modal
+ * Open the unified statistics modal, optionally scrolled to a section.
  */
 const handleOpenChart = function handleOpenChart(name: string) {
-  statisticsGraph.value = name
+  scrollToSection.value = name
   showStatisticsModal.value = true
 }
 

--- a/src/components/Layout/Header.vue
+++ b/src/components/Layout/Header.vue
@@ -16,7 +16,7 @@ const { hasAvailableMapsets } = storeToRefs(
 </script>
 
 <template>
-  <header class="app-header isolate z-50 flex items-center gap-8 border-b border-grey-200 border-t-2 border-t-green-500 px-8 py-5">
+  <header class="app-header isolate z-50 flex items-center gap-6 border-b border-grey-200 border-t-2 border-t-green-500 px-6 py-5">
     <GrayLogo />
     
     <Transition>

--- a/src/components/Modals/Statistics/ScatterChart.vue
+++ b/src/components/Modals/Statistics/ScatterChart.vue
@@ -81,7 +81,6 @@ const createChart = (): void => {
         },
       },
       plugins: {
-        title: { text: props.title, display: true },
         legend: { display: false },
         tooltip: {
           callbacks: {

--- a/src/components/Modals/Statistics/chartDefaults.ts
+++ b/src/components/Modals/Statistics/chartDefaults.ts
@@ -13,7 +13,7 @@ const COLOR_GRID = '#e8eaf1'      // grey-200 — subtle separators
 const COLOR_BG = '#ffffff'
 
 Chart.defaults.font.family = FONT_FAMILY
-Chart.defaults.font.size = 12
+Chart.defaults.font.size = 14
 Chart.defaults.color = COLOR_TEXT
 Chart.defaults.borderColor = COLOR_GRID
 
@@ -21,14 +21,22 @@ Chart.defaults.borderColor = COLOR_GRID
 // twitchy and the components disable it per-chart anyway.
 Chart.defaults.animation = false
 
-// Plugin defaults
+// Pin legend to the bottom of every chart. chart.js otherwise auto-flips
+// it to the side when the chart is narrow, producing inconsistent
+// placements across the unified Statistieken modal.
+Chart.defaults.plugins.legend.position = 'bottom'
 Chart.defaults.plugins.legend.labels.color = COLOR_TEXT
-Chart.defaults.plugins.legend.labels.boxWidth = 12
-Chart.defaults.plugins.legend.labels.boxHeight = 12
-Chart.defaults.plugins.legend.labels.padding = 12
+Chart.defaults.plugins.legend.labels.boxWidth = 14
+Chart.defaults.plugins.legend.labels.boxHeight = 14
+Chart.defaults.plugins.legend.labels.padding = 14
+Chart.defaults.plugins.legend.labels.font = { family: FONT_FAMILY, size: 14 }
 
+// Section headings own the title — disable chart.js's own title plugin
+// by default. Defaults below keep the styling sensible if a chart
+// re-enables it.
+Chart.defaults.plugins.title.display = false
 Chart.defaults.plugins.title.color = COLOR_TEXT
-Chart.defaults.plugins.title.font = { family: FONT_FAMILY, size: 14, weight: 'bold' }
+Chart.defaults.plugins.title.font = { family: FONT_FAMILY, size: 16, weight: 'bold' }
 Chart.defaults.plugins.title.padding = { top: 4, bottom: 16 }
 
 Chart.defaults.plugins.tooltip.backgroundColor = COLOR_BG
@@ -36,10 +44,10 @@ Chart.defaults.plugins.tooltip.titleColor = COLOR_TEXT
 Chart.defaults.plugins.tooltip.bodyColor = COLOR_TEXT_MUTED
 Chart.defaults.plugins.tooltip.borderColor = COLOR_GRID
 Chart.defaults.plugins.tooltip.borderWidth = 1
-Chart.defaults.plugins.tooltip.padding = 10
+Chart.defaults.plugins.tooltip.padding = 12
 Chart.defaults.plugins.tooltip.cornerRadius = 6
-Chart.defaults.plugins.tooltip.titleFont = { family: FONT_FAMILY, weight: 'bold', size: 12 }
-Chart.defaults.plugins.tooltip.bodyFont = { family: FONT_FAMILY, size: 12 }
+Chart.defaults.plugins.tooltip.titleFont = { family: FONT_FAMILY, weight: 'bold', size: 13 }
+Chart.defaults.plugins.tooltip.bodyFont = { family: FONT_FAMILY, size: 13 }
 Chart.defaults.plugins.tooltip.boxPadding = 4
 
 // Theme palette for chart fills/borders. Solid versions are used for

--- a/src/components/Modals/StatisticsModal.vue
+++ b/src/components/Modals/StatisticsModal.vue
@@ -1,335 +1,238 @@
 <script setup lang="ts">
-import { computed, type Component  } from 'vue';
-import { storeToRefs } from 'pinia';
+import { computed, nextTick, watch, type Component } from 'vue'
+import { storeToRefs } from 'pinia'
 
 import OverlayModal from '@/components/Common/OverlayModal.vue'
 
 import BarChart from '@/components/Modals/Statistics/BarChart.vue'
 import PieChart from '@/components/Modals/Statistics/PieChart.vue'
-import ScatterChart from '@/components/Modals/Statistics/ScatterChart.vue';
+import ScatterChart from '@/components/Modals/Statistics/ScatterChart.vue'
 import HorizontalBarChart from '@/components/Modals/Statistics/HorizontalBarChart.vue'
 
-import { useBuildingStore } from "@/store/buildings";
-import { useStatisticsStore } from '@/store/building/statistics';
-import { useSubsidenceStore } from '@/store/building/subsidence';
-import { IConstructionYearPair, IFoundationTypePair, IIncidentYearPair, IInquiryYearPair } from '@/datastructures/interfaces/api/IStatistics';
-import { CHART_PALETTE, CHART_PALETTE_SOFT } from './Statistics/chartDefaults';
+import { useBuildingStore } from '@/store/buildings'
+import { useStatisticsStore } from '@/store/building/statistics'
+import { useSubsidenceStore } from '@/store/building/subsidence'
+import type {
+  IConstructionYearPair,
+  IFoundationTypePair,
+  IIncidentYearPair,
+  IInquiryYearPair,
+} from '@/datastructures/interfaces/api/IStatistics'
+import { CHART_PALETTE, CHART_PALETTE_SOFT } from './Statistics/chartDefaults'
 
 const { buildingId } = storeToRefs(useBuildingStore())
 const statisticsStore = useStatisticsStore()
-const { showStatisticsModal, statisticsGraph } = storeToRefs(statisticsStore)
+const { showStatisticsModal, scrollToSection } = storeToRefs(statisticsStore)
 const subsidenceStore = useSubsidenceStore()
 
-defineEmits<{ close: [] }>()
-
-interface IComponents {
-    [key: string]: Component
-}
-const availableChartComponents: IComponents = {
-  BarChart,
-  PieChart,
-  HorizontalBarChart,
-  ScatterChart
-}
-
-
 const buildingStatistics = computed(() => {
-  if (! buildingId.value) return null
+  if (!buildingId.value) return null
   return statisticsStore.getData(buildingId.value)
 })
 
-
 const subsidenceData = computed(() => {
-  if (! buildingId.value) return []
+  if (!buildingId.value) return []
   return subsidenceStore.getData(buildingId.value)
 })
 
-
-/**
- * The chart title, based on the statistic name
- */
-const title = computed(() => {
-  switch(statisticsGraph.value) {
-
-    case 'displacement':
-      return 'Pandzakking (mm)'
-    
-    case 'foundationTypeDistribution': 
-      return 'Verhouding funderingstype in de buurt'
-
-    case 'constructionYearDistribution':
-      return 'Aantal bouwjaren per decennia in de buurt'
-
-    case 'foundationRiskDistribution':
-      return 'Verhouding funderingsrisico in de buurt'
-
-    case 'totalBuildingRestoredCount':
-      return 'Aantal herstel panden per jaar in de buurt'
-
-    case 'totalIncidentCount':
-      return 'Aantal incidenten per jaar in de buurt'
-
-    case 'municipalityIncidentCount':
-      return 'Aantal incidenten per jaar in de gemeente'
-  
-    case 'totalReportCount':
-      return 'Aantal onderzoeken per jaar in de buurt'
-
-    case 'municipalityReportCount':
-      return 'Aantal onderzoeken per jaar in de gemeente'
-  }
-
-  return 'Statistiek'
-})
-
-/**
- * The graph type, based on the statistic name
- */
-const chartComponentName = computed(() => {
-  switch(statisticsGraph.value) {
-    case 'displacement':
-      return 'ScatterChart'
-
-    case 'foundationTypeDistribution': 
-    case 'foundationRiskDistribution':
-      return 'PieChart'
-    
-    case 'constructionYearDistribution':
-      return 'BarChart'
-
-    case 'totalBuildingRestoredCount':
-    case 'totalIncidentCount':
-    case 'municipalityIncidentCount':
-    case 'totalReportCount':
-    case 'municipalityReportCount':
-      return 'HorizontalBarChart'
-  }
-
-  return ''
-})
-
-const labels = computed(() => {
-
-  switch(statisticsGraph.value) {
-    case 'displacement':
-      return []
-
-    case 'foundationTypeDistribution': 
-
-      return ['Betonnen', 'Houten paal met betonoplanger', 'Houten palen', 'Niet onderheid', 'Overige']
-
-    case 'constructionYearDistribution':
-  
-      if (! buildingStatistics.value?.constructionYearDistribution) return []
-
-      return buildingStatistics.value.constructionYearDistribution.decades.map((decade: IConstructionYearPair) => {
-        return `${decade.decade.yearFrom.substring(0, 4)}-${decade.decade.yearTo.substring(0, 4)}`
-      })
-
-    case 'foundationRiskDistribution':
-      if (! buildingStatistics.value?.foundationRiskDistribution) return []
-
-      return Object.keys(buildingStatistics.value?.foundationRiskDistribution)
-        .map(key => `Label ${key.replace('percentage', '')}`)
-
-    // TODO: API does not yet provide graph data
-    case 'totalBuildingRestoredCount':
-      if (! buildingStatistics.value?.totalBuildingRestoredCount) return []
-
-      return [ 'Aantal' ]
-
-    case 'totalIncidentCount':
-      if (! buildingStatistics.value?.totalIncidentCount) return []
-
-      return buildingStatistics.value.totalIncidentCount.map((decade: IIncidentYearPair) => {
-        return decade.year
-      })
-
-    case 'municipalityIncidentCount':
-      if (! buildingStatistics.value?.municipalityIncidentCount) return []
-
-      return buildingStatistics.value.municipalityIncidentCount.map((decade: IIncidentYearPair) => {
-        return decade.year
-      })
-
-    case 'totalReportCount': 
-      if (! buildingStatistics.value?.totalReportCount) return []
-
-      return buildingStatistics.value.totalReportCount.map((decade: IInquiryYearPair) => {
-        return decade.year
-      })
-
-    case 'municipalityReportCount': 
-      if (! buildingStatistics.value?.municipalityReportCount) return []
-
-      return buildingStatistics.value.municipalityReportCount.map((decade: IInquiryYearPair) => {
-        return decade.year
-      })
-
-  }
-
-  return ['red', 'blue', 'yellow']
-})
-
-const data = computed(() => {
-
-  if (! buildingStatistics.value) return []
-
-  switch(statisticsGraph.value) {
-
-    case 'displacement':
-      return subsidenceData.value?.map(item => {
-        return {
-          y: item.velocity,
-          x: Date.parse(item.markAt),
-          r: 2
-        }
-      })
-
-    case 'foundationTypeDistribution': 
-      if (! buildingStatistics.value.foundationTypeDistribution.foundationTypes) return []
-
-      return buildingStatistics.value.foundationTypeDistribution.foundationTypes.reduce((acc: number[], pair: IFoundationTypePair ) => {
-        switch(pair.foundationType) {
-          case 3:
-          case 11:
-          case 12:
-          case 13:
-            acc[0] = acc[0] + pair.percentage
-            return acc
-
-          case 10:
-            acc[1] = acc[1] + pair.percentage
-            return acc
-          
-          case 0:
-          case 1:
-          case 2:
-          case 15:
-          case 16:
-          case 17:
-            acc[2] = acc[2] + pair.percentage
-            return acc
-          
-          case 4:
-          case 5:
-          case 6:
-          case 7:
-          case 8:
-          case 9:
-            acc[3] = acc[3] + pair.percentage
-            return acc
-
-          default:
-            acc[4] = acc[4] + pair.percentage
-            return acc
-        }
-      }, [0, 0, 0, 0, 0])
-
-    case 'constructionYearDistribution':
-  
-      if (! buildingStatistics.value?.constructionYearDistribution) return []
-
-      return buildingStatistics.value.constructionYearDistribution.decades.map((decade: IConstructionYearPair) => {
-        return decade.totalCount
-      })
-
-    case 'foundationRiskDistribution':
-      if (! buildingStatistics.value?.foundationRiskDistribution) return []
-
-      return Object.values(buildingStatistics.value.foundationRiskDistribution)
-
-    // TODO: API does not yet provide graph data
-    case 'totalBuildingRestoredCount':
-      if (! buildingStatistics.value?.totalBuildingRestoredCount) return []
-
-      return [ buildingStatistics.value.totalBuildingRestoredCount ]
-
-    case 'totalIncidentCount':
-      if (! buildingStatistics.value?.totalIncidentCount) return []
-
-      return buildingStatistics.value.totalIncidentCount.map((decade: IIncidentYearPair) => {
-        return decade.totalCount
-      })
-
-    case 'municipalityIncidentCount':
-      if (! buildingStatistics.value?.municipalityIncidentCount) return []
-
-      return buildingStatistics.value.municipalityIncidentCount.map((decade: IIncidentYearPair) => {
-        return decade.totalCount
-      })
-
-    case 'totalReportCount': 
-      if (! buildingStatistics.value?.totalReportCount) return []
-
-      return buildingStatistics.value.totalReportCount.map((decade: IInquiryYearPair) => {
-        return decade.totalCount
-      })
-
-
-    case 'municipalityReportCount': 
-      if (! buildingStatistics.value?.municipalityReportCount) return []
-
-      return buildingStatistics.value.municipalityReportCount.map((decade: IInquiryYearPair) => {
-        return decade.totalCount
-      })
-  }
-
-  return [300, 200, 600]
-})
-
-const backgroundColors = computed(() => {
-  switch (statisticsGraph.value) {
-    case 'displacement':
-      return [CHART_PALETTE.navy]
-
-    case 'foundationTypeDistribution':
-      return [CHART_PALETTE.grey, CHART_PALETTE.yellow, CHART_PALETTE.orange,
-        CHART_PALETTE.red, CHART_PALETTE.blue]
-
-    case 'foundationRiskDistribution': {
-      const riskColorMap: Record<string, string> = {
-        'Label A': CHART_PALETTE.green,
-        'Label B': CHART_PALETTE_SOFT.green,
-        'Label C': CHART_PALETTE.yellow,
-        'Label D': CHART_PALETTE.orange,
-        'Label E': CHART_PALETTE.red,
-      }
-      return (labels.value as string[]).map(label => riskColorMap[label] ?? CHART_PALETTE.grey)
+// Foundation type buckets: collapse the 18 raw enum values to 5 user-facing
+// categories. Index 0..4 corresponds to the labels below.
+const foundationTypeBuckets = computed<number[]>(() => {
+  const stats = buildingStatistics.value?.foundationTypeDistribution?.foundationTypes ?? []
+  const out = [0, 0, 0, 0, 0]
+  for (const pair of stats as IFoundationTypePair[]) {
+    switch (pair.foundationType) {
+      case 3: case 11: case 12: case 13: out[0] += pair.percentage; break
+      case 10: out[1] += pair.percentage; break
+      case 0: case 1: case 2: case 15: case 16: case 17:
+        out[2] += pair.percentage; break
+      case 4: case 5: case 6: case 7: case 8: case 9:
+        out[3] += pair.percentage; break
+      default: out[4] += pair.percentage
     }
   }
-
-  return Object.values(CHART_PALETTE_SOFT)
+  return out
 })
 
-const borderColors = computed(() => {
-  if (statisticsGraph.value === 'displacement') return [CHART_PALETTE.navy]
-  return Object.values(CHART_PALETTE)
-})
-
-
-const handleClose = function handleClose() {
-  showStatisticsModal.value = false
+const riskColors = (labels: string[]): string[] => {
+  const map: Record<string, string> = {
+    'Label A': CHART_PALETTE.green,
+    'Label B': CHART_PALETTE_SOFT.green,
+    'Label C': CHART_PALETTE.yellow,
+    'Label D': CHART_PALETTE.orange,
+    'Label E': CHART_PALETTE.red,
+  }
+  return labels.map(l => map[l] ?? CHART_PALETTE.grey)
 }
 
+interface Section {
+  key: string
+  title: string
+  // Typed as Component (not union of specific charts) so the dynamic
+  // <component :is="..."> render doesn't try to enforce the most-strict
+  // intersection of all chart prop types — the data shape varies per
+  // chart and is validated by the chart components themselves.
+  component: Component
+  labels: string[]
+  data: number[] | { x: number; y: number; r: number }[]
+  backgroundColors: string[]
+  borderColors: string[]
+}
+
+// All chart sections rendered in the modal, in display order. Sections
+// where data is absent are filtered out. Conditional incident/report
+// pairs prefer neighborhood-level data, falling back to municipality.
+const sections = computed<Section[]>(() => {
+  const stats = buildingStatistics.value
+  if (!stats) return []
+
+  const out: Section[] = []
+
+  if (subsidenceData.value && subsidenceData.value.length > 0) {
+    out.push({
+      key: 'displacement',
+      title: 'Pandzakkingssnelheid (mm)',
+      component: ScatterChart,
+      labels: [],
+      data: subsidenceData.value.map(item => ({
+        x: Date.parse(item.markAt),
+        y: item.velocity,
+        r: 2,
+      })),
+      backgroundColors: [CHART_PALETTE.navy],
+      borderColors: [CHART_PALETTE.navy],
+    })
+  }
+
+  out.push({
+    key: 'foundationTypeDistribution',
+    title: 'Verhouding funderingstype in de buurt',
+    component: PieChart,
+    labels: ['Betonnen', 'Houten paal met betonoplanger', 'Houten palen', 'Niet onderheid', 'Overige'],
+    data: foundationTypeBuckets.value,
+    backgroundColors: [CHART_PALETTE.grey, CHART_PALETTE.yellow, CHART_PALETTE.orange,
+      CHART_PALETTE.red, CHART_PALETTE.blue],
+    borderColors: [],
+  })
+
+  const decades = stats.constructionYearDistribution?.decades ?? []
+  if (decades.length > 0) {
+    out.push({
+      key: 'constructionYearDistribution',
+      title: 'Aantal bouwjaren per decennia in de buurt',
+      component: BarChart,
+      labels: decades.map((d: IConstructionYearPair) =>
+        `${d.decade.yearFrom.substring(0, 4)}-${d.decade.yearTo.substring(0, 4)}`),
+      data: decades.map((d: IConstructionYearPair) => d.totalCount),
+      backgroundColors: Object.values(CHART_PALETTE_SOFT),
+      borderColors: Object.values(CHART_PALETTE),
+    })
+  }
+
+  if (stats.foundationRiskDistribution) {
+    const riskLabels = Object.keys(stats.foundationRiskDistribution)
+      .map(k => `Label ${k.replace('percentage', '')}`)
+    out.push({
+      key: 'foundationRiskDistribution',
+      title: 'Verhouding funderingsrisico in de buurt',
+      component: PieChart,
+      labels: riskLabels,
+      data: Object.values(stats.foundationRiskDistribution),
+      backgroundColors: riskColors(riskLabels),
+      borderColors: [],
+    })
+  }
+
+  const incidentSource = stats.totalIncidentCount.length > 0
+    ? { rows: stats.totalIncidentCount, scope: 'buurt' as const }
+    : stats.municipalityIncidentCount.length > 0
+      ? { rows: stats.municipalityIncidentCount, scope: 'gemeente' as const }
+      : null
+  if (incidentSource) {
+    out.push({
+      key: 'incidentCount',
+      title: `Aantal incidenten per jaar in de ${incidentSource.scope}`,
+      component: HorizontalBarChart,
+      labels: incidentSource.rows.map((d: IIncidentYearPair) => String(d.year)),
+      data: incidentSource.rows.map((d: IIncidentYearPair) => d.totalCount),
+      backgroundColors: Object.values(CHART_PALETTE_SOFT),
+      borderColors: Object.values(CHART_PALETTE),
+    })
+  }
+
+  const reportSource = stats.totalReportCount.length > 0
+    ? { rows: stats.totalReportCount, scope: 'buurt' as const }
+    : stats.municipalityReportCount.length > 0
+      ? { rows: stats.municipalityReportCount, scope: 'gemeente' as const }
+      : null
+  if (reportSource) {
+    out.push({
+      key: 'reportCount',
+      title: `Aantal onderzoeken per jaar in de ${reportSource.scope}`,
+      component: HorizontalBarChart,
+      labels: reportSource.rows.map((d: IInquiryYearPair) => String(d.year)),
+      data: reportSource.rows.map((d: IInquiryYearPair) => d.totalCount),
+      backgroundColors: Object.values(CHART_PALETTE_SOFT),
+      borderColors: Object.values(CHART_PALETTE),
+    })
+  }
+
+  return out
+})
+
+// When the modal opens with a target section, scroll it into view after
+// the DOM has rendered. Map legacy keys to the new merged section keys.
+const sectionAlias: Record<string, string> = {
+  totalIncidentCount: 'incidentCount',
+  municipalityIncidentCount: 'incidentCount',
+  totalReportCount: 'reportCount',
+  municipalityReportCount: 'reportCount',
+}
+
+watch(showStatisticsModal, async open => {
+  if (!open) return
+  await nextTick()
+  const target = scrollToSection.value
+  if (!target) return
+  const id = sectionAlias[target] ?? target
+  document.getElementById(`stats-section-${id}`)
+    ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  scrollToSection.value = null
+})
+
+const handleClose = (): void => {
+  showStatisticsModal.value = false
+}
 </script>
 
 <template>
   <OverlayModal
     v-if="showStatisticsModal && buildingStatistics"
-    :title="title"
+    title="Statistieken"
     @close="handleClose">
-    <div 
-      v-if="chartComponentName !== ''"
-      class="w-full">
-      <component 
-        :is="availableChartComponents[chartComponentName]"
-        :title="title" 
-        :labels="labels"
-        :data="data"
-        :background-colors="backgroundColors"
-        :border-colors="borderColors"
-      />
+    <div class="space-y-10">
+      <section
+        v-for="section in sections"
+        :id="`stats-section-${section.key}`"
+        :key="section.key"
+        class="space-y-4 scroll-mt-4"
+      >
+        <h5 class="heading-5">{{ section.title }}</h5>
+        <div class="h-80">
+          <component
+            :is="section.component"
+            :title="section.title"
+            :labels="section.labels"
+            :data="section.data"
+            :background-colors="section.backgroundColors"
+            :border-colors="section.borderColors"
+          />
+        </div>
+      </section>
+
+      <p v-if="sections.length === 0" class="text-sm text-grey-700">
+        Er zijn geen statistieken beschikbaar voor dit pand.
+      </p>
     </div>
   </OverlayModal>
 </template>

--- a/src/components/OrgsMenu.vue
+++ b/src/components/OrgsMenu.vue
@@ -4,7 +4,6 @@ import { storeToRefs } from 'pinia';
 
 import { vOnClickOutside } from '@vueuse/components'
 
-import Avatar from './Common/Avatar.vue';
 import CloseBtn from '@/components/Common/Buttons/CloseBtn.vue';
 import SwitchIcon from '@assets/svg/icons/switch.svg'
 import CheckIcon from '@assets/svg/icons/check.svg'
@@ -49,31 +48,18 @@ const handleSelectOrg = function handleSelectOrg(id: string) {
 
       <button
         v-if="organizations.length !== 1"
-        @click.prevent="handleToggle" 
-        class="button group flex p-0">
-
-        <Avatar class="aspect-square w-10 rounded-full" :name="selectedOrg.name" />
-
-        <div class="flex flex-col items-start">
-          <h2 class="heading-5">{{ selectedOrg.name }}</h2>
-          <div
-            class="flex gap-2 text-sm font-bold text-green-500 transition-colors duration-150 group-hover:text-blue-500"
-          >
-            <SwitchIcon 
-              class="aspect-square w-4"
-              aria-hidden="true"
-            />
-            Wijzig organisatie
-          </div>
+        @click.prevent="handleToggle"
+        class="button group flex flex-col items-start p-0">
+        <h2 class="heading-5">{{ selectedOrg.name }}</h2>
+        <div
+          class="flex gap-2 text-sm font-bold text-green-500 transition-colors duration-150 group-hover:text-blue-500"
+        >
+          <SwitchIcon class="aspect-square w-4" aria-hidden="true" />
+          Wijzig organisatie
         </div>
       </button>
 
-      <div v-else class="flex gap-2 p-0">
-        <Avatar class="aspect-square w-10 rounded-full" :name="selectedOrg.name" />
-        <div class="flex items-center">
-          <h2 class="heading-5">{{ selectedOrg.name }}</h2>
-        </div>
-      </div>
+      <h2 v-else class="heading-5">{{ selectedOrg.name }}</h2>
 
       <Transition name="slide-down">
         <div

--- a/src/store/building/statistics.ts
+++ b/src/store/building/statistics.ts
@@ -8,7 +8,10 @@ import { createBuildingDataLoader } from './createBuildingDataLoader'
 
 export const useStatisticsStore = defineStore('statistics', () => {
   const showStatisticsModal = ref(false)
-  const statisticsGraph = ref<string | null>(null)
+
+  // When set, the unified Statistieken modal scrolls this section into
+  // view on open. Cleared after scrolling.
+  const scrollToSection = ref<string | null>(null)
 
   const { hasBeenRetrieved, failedToLoad, hasData, getData, loadData } =
     createBuildingDataLoader<IStatistics>('statistics', api.building.getStatisticsByBuildingId)
@@ -20,6 +23,6 @@ export const useStatisticsStore = defineStore('statistics', () => {
     getData,
     loadData,
     showStatisticsModal,
-    statisticsGraph,
+    scrollToSection,
   }
 })


### PR DESCRIPTION
Three follow-ups.

statistics report:
  Replace the click-one-chart-at-a-time flow with a single Statistieken
  modal that renders every chart as a scrollable section. Each section
  has its own anchor id; the right-sidebar buttons set
  scrollToSection on the store and the modal's open watcher uses
  scrollIntoView to land the user on the requested section. Sections
  with no data are skipped. Incidents and reports collapse to one
  entry each, preferring neighborhood data over municipality.

  Drops the per-chart switch logic in StatisticsModal in favour of a
  single sections array, and renames statisticsGraph -> scrollToSection
  on the store to match its new role.

chart legibility:
  - bump default font.size 12 -> 14 across legends, ticks, tooltips.
  - pin legend.position to 'bottom' globally so chart.js doesn't auto-flip it to the side on narrower charts.
  - default title.display to false; section headings own that role in the unified report. Drop ScatterChart's per-chart title.

header trim + org name:
  Drop the avatar/icon next to the selected org in the top-left;
  show the name only. Tighten the header from px-8 gap-8 to
  px-6 gap-6 for a small left-padding reduction.