### PR TITLE
ui: persist map prefs across sessions, sidebar chevron toggle, Statis…

### DIFF
--- a/src/components/Common/Buttons/SidebarToggle.vue
+++ b/src/components/Common/Buttons/SidebarToggle.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import ChevronRightIcon from '@assets/svg/icons/chevron-right.svg'
+
+const { direction = 'right', disabled = false } = defineProps<{
+  direction?: 'left' | 'right'
+  disabled?: boolean
+}>()
+
+defineEmits<{ close: [] }>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="sidebar-toggle | group ml-auto inline-flex h-8 w-8 items-center justify-center rounded text-blue-900 transition-colors duration-150 hover:bg-grey-200 hover:text-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-1 disabled:opacity-40"
+    :disabled="disabled"
+    :aria-label="direction === 'left' ? 'Verberg zijbalk' : 'Verberg zijbalk'"
+    @click="() => disabled ? undefined : $emit('close')"
+  >
+    <ChevronRightIcon
+      class="aspect-square h-3.5 transition-transform duration-150"
+      :class="[
+        direction === 'left' ? 'rotate-180 group-hover:-translate-x-0.5' : 'group-hover:translate-x-0.5',
+      ]"
+      aria-hidden="true"
+    />
+  </button>
+</template>

--- a/src/components/Common/Panel.vue
+++ b/src/components/Common/Panel.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import CloseBtn from '@/components/Common/Buttons/CloseBtn.vue'
+import SidebarToggle from '@/components/Common/Buttons/SidebarToggle.vue'
 import FundermapsIcon from '@/components/Common/Icons/FundermapsIcon.vue';
 
-const { closeable = true } = defineProps<{
+const { closeable = true, closeDirection = 'right' } = defineProps<{
   title?: string | null
   icon?: string | null
   subtitle?: string | null
   closeable?: boolean
+  closeDirection?: 'left' | 'right'
 }>()
 
 const emit = defineEmits<{ close: [] }>()
@@ -28,9 +29,9 @@ const handleClose = function handleClose() {
         aria-hidden="true"
       />
       <h6 v-if="title" class="heading-6">{{ title }}</h6>
-      <CloseBtn 
+      <SidebarToggle
         v-if="closeable"
-        :small="false"
+        :direction="closeDirection"
         @close="handleClose" />
     </div>
     <div class="panel__content" :class="{ 'pb-4': $slots.footer }">

--- a/src/components/Layout/LeftSideBar.vue
+++ b/src/components/Layout/LeftSideBar.vue
@@ -82,8 +82,9 @@ const handleToggleLayerById = function handleOpenLayerById(layerId: string, visi
       class="panels transition-transform duration-300"
       :class="{'-translate-x-full': isShowingMapsetSelection === false}"
     >
-      <Panel 
+      <Panel
         subtitle="Selecteer een kaart"
+        close-direction="left"
         @close="isLeftSidebarOpen = false">
         <section class="grid space-y-2">
           <MenuLink
@@ -106,6 +107,7 @@ const handleToggleLayerById = function handleOpenLayerById(layerId: string, visi
       </Panel>
 
       <Panel
+        close-direction="left"
         @close="isLeftSidebarOpen = false">
         <template v-slot:subtitle>
           <FundermapsIcon

--- a/src/components/Layout/RightSideBar.vue
+++ b/src/components/Layout/RightSideBar.vue
@@ -24,7 +24,7 @@ import RightSideBarFooterLinks from '@/components/RightSideBarFooterLinks.vue';
 import { useSessionStore } from '@/store/session';
 import { useBuildingStore } from '@/store/buildings';
 import { useBuildingData } from './useBuildingData';
-import { useBuildingMenu, type BuildingMenuItem } from './useBuildingMenu';
+import { useBuildingMenu } from './useBuildingMenu';
 import { usePanelRouting } from './usePanelRouting';
 
 
@@ -33,7 +33,7 @@ const { clearBuildingId } = useBuildingStore()
 const { hasSelectedBuilding } = storeToRefs(useBuildingStore())
 
 const { failedToLoad, isLoadingCoreData, startWatching } = useBuildingData()
-const { buildingMenu, reportMenu } = useBuildingMenu()
+const { buildingMenu, actionMenu, reportMenu } = useBuildingMenu()
 const { selectedPanel, rightPanelSlide, openPanel, backToMainMenu } =
   usePanelRouting([buildingMenu, reportMenu])
 
@@ -55,13 +55,6 @@ const handleCloseSideBar = (): void => {
   isOpen.value = false
   // Delay clearing the building id until the leave animation finishes.
   setTimeout(() => { clearBuildingId() }, 300)
-}
-
-// A building-menu item either routes to a sub-panel or fires an action
-// (modal opener). Dispatch on whichever is set.
-const handleBuildingMenuClick = (item: BuildingMenuItem): void => {
-  if (item.action) item.action()
-  else if (item.panel) openPanel(item.panel, item.slug)
 }
 </script>
 
@@ -105,7 +98,7 @@ const handleBuildingMenuClick = (item: BuildingMenuItem): void => {
                 :label="MenuItem.name"
                 :disabled="MenuItem.disabled"
                 :loading="MenuItem.loading"
-                @click.prevent="handleBuildingMenuClick(MenuItem)"
+                @click.prevent="openPanel(MenuItem.panel, MenuItem.slug)"
               >
                 <FundermapsIcon
                   :name="MenuItem.icon"
@@ -117,6 +110,14 @@ const handleBuildingMenuClick = (item: BuildingMenuItem): void => {
           </section>
 
           <section class="grid space-y-2">
+            <OutlineButton
+              v-for="MenuItem in actionMenu"
+              :key="MenuItem.slug"
+              :label="MenuItem.name"
+              :disabled="MenuItem.disabled || MenuItem.loading"
+              class="w-full"
+              @click.prevent="MenuItem.action()"
+            />
             <OutlineButton
               v-for="MenuItem in reportMenu"
               :key="MenuItem.name"

--- a/src/components/Layout/useBuildingMenu.ts
+++ b/src/components/Layout/useBuildingMenu.ts
@@ -16,16 +16,19 @@ interface BaseMenuItem {
 
 export interface BuildingMenuItem extends BaseMenuItem {
   icon: string
-  // A menu item routes to a panel by name OR runs a one-shot action
-  // (e.g. opening a modal). Exactly one of the two is set.
-  panel?: string
-  action?: () => void
+  panel: string
 }
 
 // Report menu items render as buttons without an icon and always route
 // to a panel.
 export interface ReportMenuItem extends BaseMenuItem {
   panel: string
+}
+
+// Action menu items render as buttons and run a one-shot callback
+// (e.g. opening a modal) instead of routing to a panel.
+export interface ActionMenuItem extends BaseMenuItem {
+  action: () => void
 }
 
 export function useBuildingMenu() {
@@ -42,12 +45,15 @@ export function useBuildingMenu() {
       loading: false, disabled: false },
     { slug: 'foundation', panel: 'FoundationPanel', icon: 'file-foundation', name: 'Fundering',
       loading: false, disabled: false },
-    { slug: 'statistics', icon: 'graph', name: 'Statistieken',
+    { slug: 'foundation-risk', panel: 'FoundationRiskPanel', icon: 'alert', name: 'Funderingsrisico',
+      loading: false, disabled: false },
+  ])
+
+  const actionMenu = computed<ActionMenuItem[]>(() => [
+    { slug: 'statistics', name: 'Bekijk statistieken',
       loading: false,
       disabled: !!(buildingId.value && statisticsStore.failedToLoad(buildingId.value)),
       action: () => { statisticsStore.showStatisticsModal = true } },
-    { slug: 'foundation-risk', panel: 'FoundationRiskPanel', icon: 'alert', name: 'Funderingsrisico',
-      loading: false, disabled: false },
   ])
 
   const reportMenu = computed<ReportMenuItem[]>(() => [
@@ -65,5 +71,5 @@ export function useBuildingMenu() {
       disabled: !!(buildingId.value && !incidentsStore.buildingHasIncidentReports(buildingId.value)) },
   ])
 
-  return { buildingMenu, reportMenu }
+  return { buildingMenu, actionMenu, reportMenu }
 }

--- a/src/components/Mapbox/useLayerVisibility.ts
+++ b/src/components/Mapbox/useLayerVisibility.ts
@@ -103,7 +103,7 @@ export const useLayerVisibility = function useLayerVisibility(
   }
 
   /**
-   * Reveal layers that were previously enabled (by referencing sessionStorage)
+   * Reveal layers that were previously enabled (by referencing localStorage)
    *  If none were enabled, enable the first layer of the layerSet
    */
   const setLayerVisibilityForMapset = function setLayerVisibilityForMapset(

--- a/src/router/mapsetRouting.ts
+++ b/src/router/mapsetRouting.ts
@@ -40,12 +40,12 @@ export const useMapsetRouting = function useMapsetRouting() {
   watch(
     () => route.params.mapsetId,
     async () => {
-      const publicMapsetSessionKey = 'last-viewed-public-mapset'
-      const privateMapsetSessionKey = 'last-viewed-private-mapset'
+      const publicMapsetStorageKey = 'last-viewed-public-mapset'
+      const privateMapsetStorageKey = 'last-viewed-private-mapset'
 
       const mapsetId = route.params?.mapsetId
-        || sessionStorage.getItem(publicMapsetSessionKey)
-        || sessionStorage.getItem(privateMapsetSessionKey)
+        || localStorage.getItem(publicMapsetStorageKey)
+        || localStorage.getItem(privateMapsetStorageKey)
 
       // Logged in, but no private mapsets available yet? Load them first
       if (isAuthenticated.value && ! hasAvailablePrivateMapsets.value) {
@@ -63,9 +63,9 @@ export const useMapsetRouting = function useMapsetRouting() {
         // If (now) available, mark it as the last visited mapset and select it
         if (isMapsetAvailable(mapsetId as string)) {
           if (isPublicMapset(mapsetId as string)) {
-            sessionStorage.setItem(publicMapsetSessionKey, mapsetId.toString())
+            localStorage.setItem(publicMapsetStorageKey, mapsetId.toString())
           } else {
-            sessionStorage.setItem(privateMapsetSessionKey, mapsetId.toString())
+            localStorage.setItem(privateMapsetStorageKey, mapsetId.toString())
           }
 
           selectMapsetById(mapsetId as string)
@@ -76,7 +76,7 @@ export const useMapsetRouting = function useMapsetRouting() {
       // Unable to load the requested mapset and not logged in
       if (! isAuthenticated.value) {
         // Try to redirect to the last visited public mapset
-        const lastPublic = sessionStorage.getItem(publicMapsetSessionKey)
+        const lastPublic = localStorage.getItem(publicMapsetStorageKey)
         if (lastPublic && mapsetId !== lastPublic) {
           navigateToMapset(lastPublic)
         } else {
@@ -87,7 +87,7 @@ export const useMapsetRouting = function useMapsetRouting() {
 
       // Logged in and no mapsets available at all
       if (! hasAvailableMapsets.value) {
-        const lastPublic = sessionStorage.getItem(publicMapsetSessionKey)
+        const lastPublic = localStorage.getItem(publicMapsetStorageKey)
         if (lastPublic && mapsetId !== lastPublic) {
           navigateToMapset(lastPublic)
         }

--- a/src/store/layers.ts
+++ b/src/store/layers.ts
@@ -2,10 +2,10 @@ import { defineStore, storeToRefs } from 'pinia';
 import { ref } from 'vue';
 
 import { useMapsetStore } from '@/store/mapsets';
-import { getItemsStartingWith } from '@/utils/sessionStorage';
+import { getItemsStartingWith } from '@/utils/localStorage';
 
-// A full session storage key = prefix + mapsetId
-const sessionStorageKeyPrefix = 'layer_visibility_';
+// A full localStorage key = prefix + mapsetId
+const storageKeyPrefix = 'layer_visibility_';
 
 /**
  * Defines the store for managing layer visibility and related settings.
@@ -99,34 +99,34 @@ export const useLayersStore = defineStore('layers', () => {
   };
 
   /**
-   * Loads layer visibility information from session storage for all mapsets.
+   * Loads layer visibility information from localStorage for all mapsets.
    * This is typically called once at application startup to restore previous state.
    */
-  const retrieveLayerVisibilityFromSessionStorage = (): void => {
+  const retrieveLayerVisibility = (): void => {
     try {
-      const visibilityPerMapset = getItemsStartingWith(sessionStorageKeyPrefix);
+      const visibilityPerMapset = getItemsStartingWith(storageKeyPrefix);
       Object.keys(visibilityPerMapset).forEach(key => {
-        const id = key.substring(sessionStorageKeyPrefix.length);
+        const id = key.substring(storageKeyPrefix.length);
         if (id) { // Ensure id is not empty (e.g., if key was exactly the prefix)
           try {
             const parsedLayers = JSON.parse(visibilityPerMapset[key]);
             if (Array.isArray(parsedLayers) && parsedLayers.every(item => typeof item === 'string')) {
               visibleLayersByMapsetId.value[id] = parsedLayers;
             } else {
-              console.warn(`Invalid layer visibility data in session storage for mapset ${id}: not an array of strings.`);
+              console.warn(`Invalid layer visibility data in localStorage for mapset ${id}: not an array of strings.`);
             }
           } catch (parseError) {
-            console.error(`Failed to parse layer visibility for mapset ${id} from session storage:`, parseError);
+            console.error(`Failed to parse layer visibility for mapset ${id} from localStorage:`, parseError);
           }
         }
       });
     } catch (e) {
-      console.error("Failed to retrieve layer visibility information from session storage. Starting with default settings.", e);
+      console.error("Failed to retrieve layer visibility information from localStorage. Starting with default settings.", e);
     }
   };
 
   /**
-   * Changes the visibility of a layer for a specific mapset and updates session storage.
+   * Changes the visibility of a layer for a specific mapset and updates localStorage.
    * @param {string} layerId - The ID of the layer whose visibility is to be changed.
    * @param {boolean} visibility - The new visibility state (true for visible, false for hidden).
    * @param {string | null | undefined} mapsetIdInput - The mapset ID or identifier; defaults to the active mapset if null or undefined.
@@ -158,12 +158,12 @@ export const useLayersStore = defineStore('layers', () => {
     if (JSON.stringify(currentVisibleForMapset) !== JSON.stringify(futureVisibleLayers)) {
       visibleLayersByMapsetId.value[finalMapsetId] = futureVisibleLayers;
       try {
-        sessionStorage.setItem(
-          `${sessionStorageKeyPrefix}${finalMapsetId}`,
+        localStorage.setItem(
+          `${storageKeyPrefix}${finalMapsetId}`,
           JSON.stringify(futureVisibleLayers)
         );
       } catch (e) {
-        console.error(`Failed to save layer visibility to session storage for mapset ${finalMapsetId}:`, e);
+        console.error(`Failed to save layer visibility to localStorage for mapset ${finalMapsetId}:`, e);
       }
     }
   };
@@ -193,7 +193,7 @@ export const useLayersStore = defineStore('layers', () => {
     getVisibleLayersByMapsetId,
     getVisibleLayersOfActiveMapset,
     isLayerVisible,
-    retrieveLayerVisibilityFromSessionStorage,
+    retrieveLayerVisibility,
     changeLayerVisibility,
     toggleLayerVisibility,
   };

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,8 +1,8 @@
 export const getItemsStartingWith = (str: string): Record<string, string> => {
-  return Object.keys(sessionStorage)
+  return Object.keys(localStorage)
     .filter(key => key.startsWith(str))
     .reduce((acc: { [key: string]: string }, key: string) => {
-      const val = sessionStorage.getItem(key)
+      const val = localStorage.getItem(key)
       if (val) acc[key] = val
       return acc
     }, {})

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -43,7 +43,7 @@ const {
 } = useMapsetStore()
 
 const {
-  retrieveLayerVisibilityFromSessionStorage
+  retrieveLayerVisibility
 } = useLayersStore()
 
 const {
@@ -104,7 +104,7 @@ watch(() => hasAvailableMapsets.value, (value, oldValue) => {
  * The layer visibility impacts both the legend and the map
  */
 onBeforeMount(() => {
-  retrieveLayerVisibilityFromSessionStorage()
+  retrieveLayerVisibility()
 })
 
 /**


### PR DESCRIPTION
…tieken as outline button

* Layer visibility per mapset and last-viewed public/private mapset IDs now live in localStorage so they survive logout / browser restart (utils/sessionStorage.ts → utils/localStorage.ts; layers store + mapsetRouting migrated; AccordionItem keeps sessionStorage as per-tab UI state). retrieveLayerVisibilityFromSessionStorage renamed to retrieveLayerVisibility.
* New SidebarToggle replaces CloseBtn inside Panel.vue. Direction prop ('left' | 'right') flips the chevron; left sidebar opts in via close-direction="left", right sidebar + sub-panels inherit default. Modals/SearchBar/OrgsMenu still use CloseBtn unchanged.
* Statistieken moves out of buildingMenu (icon link) into a new actionMenu group rendered as OutlineButton between buildingMenu and reportMenu. BuildingMenuItem simplified — panel is now required, no more action dispatch in RightSideBar.