### PR TITLE
fix(mapset): handle TS API single-object response on /mapset/:id

### DIFF
--- a/src/services/api/mapset.ts
+++ b/src/services/api/mapset.ts
@@ -43,10 +43,13 @@ export const getAvailableMapsets = async (): Promise<IMapsetFE[]> => {
   return response.map(mapMapset)
 }
 
-export const getPublicAndAvailableMapsetsById = async (id: string): Promise<IMapsetFE[]> => {
-  const response = await get({ endpoint: `/mapset/${id}`, requireAuth: false }) as RawMapset[] | null
-  if (!response) throw new Error(`Failed to retrieve mapset: ${id}`)
-  return response.map(mapMapset)
+// /api/mapset/:id returns a single object (the public mapset matching the
+// id or slug, or 404). Older C# contract returned an array — the TS API
+// returns one object directly, so don't .map() over it.
+export const getPublicAndAvailableMapsetsById = async (id: string): Promise<IMapsetFE | null> => {
+  const response = await get({ endpoint: `/mapset/${id}`, requireAuth: false }) as RawMapset | null
+  if (!response) return null
+  return mapMapset(response)
 }
 
 export default {

--- a/src/store/mapsets.ts
+++ b/src/store/mapsets.ts
@@ -209,11 +209,11 @@ function useMapsets() {
     isLoadingMapsets.value = true
 
     try {
-      const response = await api.mapset.getPublicAndAvailableMapsetsById(mapsetId)
-      response.forEach((mapset: IMapsetFE) => {
+      const mapset = await api.mapset.getPublicAndAvailableMapsetsById(mapsetId)
+      if (mapset) {
         const enforced = enforceGeoFencingOnPublicMapsets(mapset)
         availableMapsetsById.value[enforced.id] = enforced
-      })
+      }
     } catch (e) {
       console.error('Failed to load mapset by id:', mapsetId, e)
     }


### PR DESCRIPTION
The TS API returns one object from /api/mapset/:id (or 404), not an array. The frontend was calling .map() on the response and silently swallowing the resulting TypeError, leaving the public mapset unloaded — which then bounced unauthenticated visitors of e.g. /map/schiedam-publiek to the login screen via the "unable to load + not logged in" branch in mapsetRouting.ts.

Adjust the API wrapper to return IMapsetFE | null and update the single store consumer to handle one object.