### PR TITLE
feat(pdf): submit + poll for async PDF generation

### DIFF
--- a/src/services/api/pdf.ts
+++ b/src/services/api/pdf.ts
@@ -1,8 +1,26 @@
-import { get } from "../apiClient"
+import { get, post } from "../apiClient"
+
+const POLL_INTERVAL_MS = 2000
+const POLL_TIMEOUT_MS = 5 * 60 * 1000
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
 
 export const getPdf = async (buildingId: string): Promise<string> => {
-  const response = await get({ endpoint: `/pdf/${buildingId}` })
-  return (response as { accessLink: string }).accessLink
+  const submission = await post({ endpoint: `/pdf/${buildingId}` }) as { jobId: string }
+  const { jobId } = submission
+
+  const deadline = Date.now() + POLL_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    const status = await get({ endpoint: `/pdf/job/${jobId}` }) as {
+      status: 'working' | 'success' | 'failed'
+      accessLink?: string
+    }
+    if (status.status === 'success' && status.accessLink) return status.accessLink
+    if (status.status === 'failed') throw new Error('PDF generation failed')
+    await sleep(POLL_INTERVAL_MS)
+  }
+
+  throw new Error('PDF generation timed out')
 }
 
 export default {


### PR DESCRIPTION
## Summary
- \`getPdf()\` now submits via POST then polls \`/pdf/job/:jobId\` every 2s (5 min cap) until success.
- Removes the long inline wait that surfaced as a 504 from DO App Platform.
- Public \`Promise<string>\` contract preserved; \`RightSideBarFooterLinks\` unchanged.

Pairs with FunderMapsApi PR \`feature/pdf-async\` (TS API split into POST submit + GET status). Merge order: API first.

## Test plan
- [ ] Click "PDF downloaden" in the right sidebar — button shows "PDF wordt aangemaakt..." while polling, then triggers the download
- [ ] Verify polling backs off after 5 minutes with a clear error if pdf.co reports failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)