### PR TITLE
chore(layers): rename boundry-* layers to boundary-*

### DIFF
--- a/src/components/Mapbox/useAdministrativeBoundries.ts
+++ b/src/components/Mapbox/useAdministrativeBoundries.ts
@@ -17,9 +17,9 @@ export const useAdminstrativeBoundaries = function useAdminstrativeBoundaries(
     Map, 
     toggleValue, 
     [
-      'boundry-municipality',
-      'boundry-neighborhood',
-      'boundry-district'
+      'boundary-municipality',
+      'boundary-neighborhood',
+      'boundary-district'
     ]
   )
 }

--- a/src/components/Mapbox/useMapSources.ts
+++ b/src/components/Mapbox/useMapSources.ts
@@ -19,7 +19,7 @@ export const useMapSources = function useMapSources(
   }
 
   const sourceZoomLevels: Record<string, { min?: number, max?: number }> = {
-    'boundry_municipality': {
+    'boundary_municipality': {
       min: 7,
       max: 11
     },

--- a/src/config/layers/boundary-district.json
+++ b/src/config/layers/boundary-district.json
@@ -1,8 +1,8 @@
 {
-  "id": "boundry-district",
+  "id": "boundary-district",
   "type": "line",
-  "source": "boundry_district",
-  "source-layer": "boundry_district",
+  "source": "boundary_district",
+  "source-layer": "boundary_district",
   "minzoom": 10,
   "layout": {"visibility": "none"},
   "paint": {

--- a/src/config/layers/boundary-municipality.json
+++ b/src/config/layers/boundary-municipality.json
@@ -1,8 +1,8 @@
 {
-  "id": "boundry-municipality",
+  "id": "boundary-municipality",
   "type": "line",
-  "source": "boundry_municipality",
-  "source-layer": "boundry_municipality",
+  "source": "boundary_municipality",
+  "source-layer": "boundary_municipality",
   "minzoom": 10,
   "layout": {"visibility": "none"},
   "paint": {

--- a/src/config/layers/boundary-neighborhood.json
+++ b/src/config/layers/boundary-neighborhood.json
@@ -1,8 +1,8 @@
 {
-  "id": "boundry-neighborhood",
+  "id": "boundary-neighborhood",
   "type": "line",
-  "source": "boundry_neighborhood",
-  "source-layer": "boundry_neighborhood",
+  "source": "boundary_neighborhood",
+  "source-layer": "boundary_neighborhood",
   "minzoom": 10,
   "layout": {"visibility": "none"},
   "paint": {


### PR DESCRIPTION
Fixes the long-standing "boundry" typo on the three administrative- boundary tile layers. Renames the JSON layer configs, updates the id/source/source-layer fields, and points useAdministrativeBoundries
+ useMapSources at the new tileset names.

Ship after FunderMapsWorker chore/rename-boundry-to-boundary has been applied to prod AND a process-mapset cycle has materialized the new boundary_*.mbtiles on S3 — until then the new layer requests will 404 against the tile bucket.