### PR TITLE
feat(pdf): consume sync /api/pdf bytes via object URL

### DIFF
--- a/src/components/RightSideBarFooterLinks.vue
+++ b/src/components/RightSideBarFooterLinks.vue
@@ -19,18 +19,16 @@ const handleDownload = async function handleDownload() {
     // Ensure the appropriate filename is used even if the user navigates away while the download is still being processed
     const filename = buildingId.value + ''
 
-    const response = await getPdf(filename)
-
-    const res = await fetch(response)
-    const blob = await res.blob()
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${filename}.pdf`
-    a.click()
-    URL.revokeObjectURL(url)
-
-    isDownloading.value = false
+    try {
+      const url = await getPdf(filename)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${filename}.pdf`
+      a.click()
+      URL.revokeObjectURL(url)
+    } finally {
+      isDownloading.value = false
+    }
   }
 }
 

--- a/src/services/api/pdf.ts
+++ b/src/services/api/pdf.ts
@@ -1,28 +1,28 @@
-import { get, post } from "../apiClient"
+import { apiBasePath } from "@/config"
+import { getAuthHeader, hasToken } from "@/services/token"
+import { trimTrailingChar } from "@/utils/string"
 
-const POLL_INTERVAL_MS = 2000
-const POLL_TIMEOUT_MS = 5 * 60 * 1000
-
-const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
-
+// Sync render against the API's Gotenberg-backed /api/pdf/:id endpoint. The
+// API holds the request while Gotenberg renders the report front-end, then
+// streams `application/pdf` bytes back. We wrap them in an object URL so the
+// caller (anchor href / window.open) can treat it like a hosted link.
+//
+// Returned URL is owned by the caller — `URL.revokeObjectURL` it when the
+// view is torn down to avoid leaking blob memory.
 export const getPdf = async (buildingId: string): Promise<string> => {
-  const submission = await post({ endpoint: `/pdf/${buildingId}` }) as { jobId: string }
-  const { jobId } = submission
+  if (!hasToken()) throw new Error("Missing access token")
 
-  const deadline = Date.now() + POLL_TIMEOUT_MS
-  while (Date.now() < deadline) {
-    const status = await get({ endpoint: `/pdf/job/${jobId}` }) as {
-      status: 'working' | 'success' | 'failed'
-      accessLink?: string
-    }
-    if (status.status === 'success' && status.accessLink) return status.accessLink
-    if (status.status === 'failed') throw new Error('PDF generation failed')
-    await sleep(POLL_INTERVAL_MS)
-  }
+  const url = `${trimTrailingChar(apiBasePath, "/")}/api/pdf/${encodeURIComponent(buildingId)}`
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { ...getAuthHeader() },
+  })
+  if (!response.ok) throw new Error(`PDF generation failed (HTTP ${response.status})`)
 
-  throw new Error('PDF generation timed out')
+  const blob = await response.blob()
+  return URL.createObjectURL(blob)
 }
 
 export default {
-  getPdf
+  getPdf,
 }


### PR DESCRIPTION
## Summary
- `services/api/pdf.ts` drops the pdf.co-era poll loop. New shape: single `POST /api/pdf/:building_id`, the API now streams `application/pdf` inline, we wrap the response blob in `URL.createObjectURL(...)` and return that URL.
- `RightSideBarFooterLinks.vue`: the old caller did a redundant second `fetch(hostedUrl)` to materialize a blob — that hop is gone, `getPdf` already hands back an object URL.

## Coordinated PRs
- FunderMapsApi#52 — sync `/api/pdf/:id` rewrite + `GOTENBERG_URL` env.
- FunderMapsWorker#16 — `generate_pdf` job swap.

## Validated E2E on the local stack
Frontend not exercised in a browser yet — `vue-tsc --noEmit` clean and the service layer is a thin `fetch` + `blob()` + `URL.createObjectURL`. The API side was proven end-to-end (Gotenberg → API → 200 application/pdf 15 KB).

## Test plan
- [ ] Spin a build with `VITE_FUNDERMAPS_URL` pointing at a deployed API on the Gotenberg branch.
- [ ] Sign in, open a building's sidebar, click "PDF downloaden", confirm the PDF downloads with the expected filename and content.
- [ ] Verify `URL.revokeObjectURL` is called (no leaking blob URLs on repeated clicks).
- [ ] Merge after `FunderMapsApi#52` so the new bytes contract is what's actually deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)