### PR TITLE
feat(auth): WebFront as an OIDC client (with silent refresh)

### DIFF
--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -15,6 +15,7 @@ import ChevronDownIcon from '@assets/svg/icons/chevron-down.svg'
 
 import { useSessionStore } from '@/store/session';
 import { useMainStore } from '@/store/main'
+import { logoutRedirect } from '@/services/oidc'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -60,10 +61,11 @@ const handleOpenPasswordModal = function() {
   isOpen.value = false
 }
 
-const handleLogout = async function() {
-  await sessionStore.logout()
+const handleLogout = function() {
   isOpen.value = false
-  router.push({ name: 'login' })
+  // RP-initiated logout: end the SSO session at the provider and return to the
+  // map as a guest (oidc.ts). A local-only logout would silently re-login.
+  logoutRedirect()
 }
 
 /**

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
 import Home from '@/views/Main.vue'
+import { loginRedirect } from '@/services/oidc'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -12,7 +13,18 @@ const router = createRouter({
     {
       name: 'login',
       path: '/login',
-      component: () => import('@/views/auth/Login.vue')
+      component: () => import('@/views/auth/Login.vue'),
+      // Login lives in the auth app (auth.fundermaps.com). Redirect to the OIDC
+      // flow before the component renders, so no local login page flashes.
+      beforeEnter: async () => {
+        await loginRedirect()
+        return false
+      },
+    },
+    {
+      name: 'auth-callback',
+      path: '/auth/callback',
+      component: () => import('@/views/auth/Callback.vue'),
     },
     {
       name: 'forgotten',

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,6 +1,7 @@
 import { apiBasePath } from "@/config"
 import { trimLeadingChar, trimTrailingChar } from "@/utils/string"
-import { getAuthHeader, hasToken, removeAccessToken } from '@/services/token'
+import { getAuthHeader, hasToken, removeTokens } from '@/services/token'
+import { refresh } from '@/services/oidc'
 import { emitAuthExpired } from '@/services/authEvents'
 
 type Method = 'GET' | 'POST' | 'PUT'
@@ -13,9 +14,8 @@ interface CallOptions {
   signal?: AbortSignal
 }
 
-const makeCall = async ({
-  endpoint, method = 'GET', body, requireAuth = true, signal,
-}: CallOptions): Promise<unknown> => {
+const makeCall = async (opts: CallOptions, _retried = false): Promise<unknown> => {
+  const { endpoint, method = 'GET', body, requireAuth = true, signal } = opts
   let fetchOptions: RequestInit = {}
   let responseBody: unknown = null
 
@@ -51,10 +51,14 @@ const makeCall = async ({
     }
 
     if (!response.ok) {
-      // Server says our token is no good. Drop it locally and signal the
-      // shell so it can clear session state and navigate to login.
+      // 401 — the access token likely expired. Try a single silent refresh and
+      // retry, so the user (and the map) isn't bounced to login. Only if the
+      // refresh fails do we drop the session and signal the shell.
       if (requireAuth && response.status === 401) {
-        removeAccessToken()
+        if (!_retried && (await refresh())) {
+          return makeCall(opts, true)
+        }
+        removeTokens()
         emitAuthExpired()
         throw new APITokenError('Server rejected token (401)')
       }

--- a/src/services/oidc.ts
+++ b/src/services/oidc.ts
@@ -1,0 +1,147 @@
+/**
+ * OIDC (authorization-code + PKCE) client for the FunderMaps auth provider.
+ *
+ * WebFront is a trusted first-party OIDC client. Login happens at the auth app
+ * (auth.fundermaps.com); we exchange the returned code for an access token + a
+ * refresh token (offline_access). The access token is short-lived (1h); when it
+ * expires the API client silently calls refresh() instead of bouncing the user
+ * to login — important for the map, which we don't want to reload mid-session.
+ * Guest browsing (public mapsets) keeps working without any of this.
+ */
+import { apiBasePath } from '@/config'
+import {
+  getIdToken,
+  getRefreshToken,
+  removeTokens,
+  storeTokens,
+} from '@/services/token'
+
+const API = apiBasePath.replace(/\/+$/, '')
+const CLIENT_ID = 'webfront'
+const VERIFIER_KEY = 'oidc_pkce_verifier'
+const STATE_KEY = 'oidc_state'
+
+const redirectUri = (): string => `${window.location.origin}/auth/callback`
+const postLogoutUri = (): string => `${window.location.origin}/`
+
+function base64url(bytes: Uint8Array): string {
+  let bin = ''
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function randomUrlSafe(byteLength: number): string {
+  return base64url(crypto.getRandomValues(new Uint8Array(byteLength)))
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))
+  return base64url(new Uint8Array(digest))
+}
+
+/** Begin login: stash PKCE verifier + state, navigate to /oauth2/authorize. */
+export async function loginRedirect(): Promise<void> {
+  const verifier = randomUrlSafe(48)
+  const state = randomUrlSafe(16)
+  sessionStorage.setItem(VERIFIER_KEY, verifier)
+  sessionStorage.setItem(STATE_KEY, state)
+
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: redirectUri(),
+    // offline_access → the provider also issues a refresh token.
+    scope: 'openid email profile offline_access',
+    state,
+    code_challenge: await pkceChallenge(verifier),
+    code_challenge_method: 'S256',
+  })
+  window.location.assign(`${API}/api/auth/oauth2/authorize?${params.toString()}`)
+}
+
+/** Finish login: validate state, exchange the code for tokens, store them. */
+export async function exchangeCode(code: string, state: string): Promise<void> {
+  const verifier = sessionStorage.getItem(VERIFIER_KEY)
+  const expectedState = sessionStorage.getItem(STATE_KEY)
+  if (!verifier || !state || state !== expectedState) {
+    throw new Error('Invalid OIDC state')
+  }
+
+  const res = await fetch(`${API}/api/auth/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri(),
+      client_id: CLIENT_ID,
+      code_verifier: verifier,
+    }),
+  })
+  if (!res.ok) throw new Error(`Token exchange failed (${res.status})`)
+  const tokens = await res.json()
+  if (!tokens.access_token) throw new Error('No access token in token response')
+
+  storeTokens(tokens)
+  sessionStorage.removeItem(VERIFIER_KEY)
+  sessionStorage.removeItem(STATE_KEY)
+}
+
+// Single-flight refresh: concurrent 401s share one refresh round-trip.
+let refreshInFlight: Promise<boolean> | null = null
+
+/**
+ * Exchange the (rotated) refresh token for a fresh access token. Returns true
+ * on success (tokens stored). Returns false if there's no refresh token or the
+ * provider rejects it — the caller then treats the session as expired.
+ */
+export function refresh(): Promise<boolean> {
+  if (refreshInFlight) return refreshInFlight
+  refreshInFlight = doRefresh().finally(() => {
+    refreshInFlight = null
+  })
+  return refreshInFlight
+}
+
+async function doRefresh(): Promise<boolean> {
+  const refreshToken = getRefreshToken()
+  if (!refreshToken) return false
+  try {
+    const res = await fetch(`${API}/api/auth/oauth2/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: CLIENT_ID,
+      }),
+    })
+    if (!res.ok) return false
+    const tokens = await res.json()
+    if (!tokens.access_token) return false
+    storeTokens(tokens) // rotates the refresh token too
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * RP-initiated logout: clear local tokens, then end the SSO session at the
+ * provider and return to the map (as a guest). Falls back to a plain reload to
+ * home if there's no id_token to hint with.
+ */
+export function logoutRedirect(): void {
+  const idToken = getIdToken()
+  removeTokens()
+  if (!idToken) {
+    window.location.assign(postLogoutUri())
+    return
+  }
+  const params = new URLSearchParams({
+    id_token_hint: idToken,
+    post_logout_redirect_uri: postLogoutUri(),
+    client_id: CLIENT_ID,
+  })
+  window.location.assign(`${API}/api/auth/oauth2/end-session?${params.toString()}`)
+}

--- a/src/services/token.ts
+++ b/src/services/token.ts
@@ -4,9 +4,22 @@
 // redirect to login. Replaces the old jwt.ts.
 
 const access_token_key = 'access_token';
+// OIDC refresh token (rotated on every use) + id_token (for RP-logout's
+// id_token_hint). The access token is short-lived (1h); on a 401 the API client
+// silently refreshes via the refresh token, so the user isn't bounced to login.
+const refresh_token_key = 'refresh_token';
+const id_token_key = 'id_token';
 
 export function getAccessToken(): string | null {
   return localStorage.getItem(access_token_key);
+}
+
+export function getRefreshToken(): string | null {
+  return localStorage.getItem(refresh_token_key);
+}
+
+export function getIdToken(): string | null {
+  return localStorage.getItem(id_token_key);
 }
 
 export function hasToken(): boolean {
@@ -23,6 +36,24 @@ export function storeAccessToken(token: string): void {
   localStorage.setItem(access_token_key, token);
 }
 
+/** Store the full token set from an OIDC token response (rotates refresh token). */
+export function storeTokens(t: {
+  access_token: string;
+  refresh_token?: string;
+  id_token?: string;
+}): void {
+  localStorage.setItem(access_token_key, t.access_token);
+  if (t.refresh_token) localStorage.setItem(refresh_token_key, t.refresh_token);
+  if (t.id_token) localStorage.setItem(id_token_key, t.id_token);
+}
+
 export function removeAccessToken(): void {
   localStorage.removeItem(access_token_key);
+}
+
+/** Clear every stored token (access + refresh + id). */
+export function removeTokens(): void {
+  localStorage.removeItem(access_token_key);
+  localStorage.removeItem(refresh_token_key);
+  localStorage.removeItem(id_token_key);
 }

--- a/src/store/session.ts
+++ b/src/store/session.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia';
 
 import type { IUser } from '@/datastructures/interfaces';
 import api from '@/services/api';
-import { hasToken, removeAccessToken, storeAccessToken } from '@/services/token';
+import { hasToken, removeTokens, storeAccessToken } from '@/services/token';
 
 import { useMapsetStore } from '@/store/mapsets';
 import { useMetadataStore } from './metadata';
@@ -120,7 +120,7 @@ export const useSessionStore = defineStore('session', () => {
     // expired session) we still want to log out client-side.
     try { await api.auth.signOut(); } catch { /* swallow */ }
 
-    removeAccessToken();
+    removeTokens();
     currentUser.value = null;
     selectedOrgId.value = null;
 

--- a/src/views/auth/Callback.vue
+++ b/src/views/auth/Callback.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import { exchangeCode } from '@/services/oidc'
+import { useSessionStore } from '@/store/session'
+
+const route = useRoute()
+const router = useRouter()
+const sessionStore = useSessionStore()
+
+const error = ref(false)
+
+onMounted(async () => {
+  const code = route.query.code
+  const state = route.query.state
+  if (typeof code !== 'string') {
+    error.value = true
+    return
+  }
+  try {
+    await exchangeCode(code, typeof state === 'string' ? state : '')
+    await sessionStore.authenticateFromAccessToken()
+    router.replace({ name: 'home' })
+  } catch (e) {
+    console.error('OIDC callback failed:', e)
+    error.value = true
+  }
+})
+</script>
+
+<template>
+  <!-- Neutral loading during the code exchange — not the login chrome. -->
+  <div class="grid min-h-screen place-content-center text-grey-700">
+    <p v-if="error" class="text-sm">
+      Inloggen mislukt.
+      <RouterLink :to="{ name: 'login' }" class="text-green-700 underline">Opnieuw proberen</RouterLink>
+    </p>
+    <p v-else class="text-sm">Bezig met inloggen…</p>
+  </div>
+</template>


### PR DESCRIPTION
WebFront joins SSO — login via the auth app (`auth.fundermaps.com`), authorization-code + PKCE. Because OIDC access tokens are 1h, WebFront uses a **refresh token** to silently renew (no mid-session map reload), per the agreed approach.

- **`services/oidc.ts`** — PKCE `loginRedirect` (requests `offline_access`), `exchangeCode`, `refresh()` (single-flight; stores the rotated refresh token), `logoutRedirect` (RP-initiated → back to the map as guest).
- **`services/token.ts`** — store/clear refresh + id tokens alongside the access token.
- **`services/apiClient.ts`** — on **401, silently refresh + retry once**; only signal auth-expired (→ login) if refresh fails. Guest browsing (public mapsets) is untouched.
- **router** — `/login` redirects to OIDC before render; new `/auth/callback`.
- **session store + UserMenu** — logout is now RP-initiated (ends the SSO session, returns to the map). Login stays on-demand.

**Requires** the `webfront` client — FunderMapsWorker#25 (apply before/with deploy). Also needs the auth app + API OIDC PRs already deployed.

Verified the client end-to-end locally: authorize → login → code → token (with refresh_token) → access auths `/api/user` → refresh grant → working new token → end-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)