### PR TITLE
fix(auth): OIDC login fails with 'Invalid OIDC state'

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,13 @@ const sessionStore = useSessionStore()
 const metadataStore = useMetadataStore()
 const { isAuthenticated } = storeToRefs(sessionStore)
 
-sessionStore.authenticateFromAccessToken()
+// Skip session restore on the OIDC callback — Callback.vue owns auth there
+// (it exchanges the code). Restoring here would, with no token yet, run
+// logout() → sessionStorage.clear(), wiping the PKCE state before the exchange
+// ("Invalid OIDC state").
+if (window.location.pathname !== '/auth/callback') {
+  sessionStore.authenticateFromAccessToken()
+}
 
 // Refetch metadata whenever the user becomes authenticated. Covers three
 // cases: fresh login (false -> true), session restore on page load


### PR DESCRIPTION
Login on the maps app failed at the callback with `Invalid OIDC state`. Cause: `App.vue` runs `authenticateFromAccessToken()` on every load; on `/auth/callback` there's no token yet, so it falls into `logout()` → **`sessionStorage.clear()`**, wiping the PKCE verifier/state before `exchangeCode` reads them. (ClientApp didn't hit this — its logout doesn't clear sessionStorage.)

Fix: skip the session restore on `/auth/callback` — `Callback.vue` owns auth there (it exchanges the code, then loads the user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)