### PR TITLE
fix(auth): end the SSO session on logout from the no-mapsets modal

### DIFF
--- a/src/components/Modals/NoMapsetsModal.vue
+++ b/src/components/Modals/NoMapsetsModal.vue
@@ -6,21 +6,21 @@ import OverlayModal from '@/components/Common/OverlayModal.vue';
 import ExitIcon from '@assets/svg/icons/exit.svg'
 
 import { useMapsetStore } from '@/store/mapsets'
-import { useRouter } from 'vue-router'
 import { useSessionStore } from '@/store/session';
+import { logoutRedirect } from '@/services/oidc'
 
 
 const { noMapsetsFound } = storeToRefs( useMapsetStore() )
-const router = useRouter()
-const sessionStore = useSessionStore()
 const { isAuthenticated } = storeToRefs( useSessionStore() )
 
 /**
- * Log the user out, and redirect to the login page
+ * Log the user out. RP-initiated (ends the SSO session at the provider), not a
+ * local-only clear — otherwise the next /authorize silently re-signs-in the
+ * same no-mapsets user, defeating the point of this button (switch accounts).
+ * Matches UserMenu's logout.
  */
-const handleLogout = async function() {
-  await sessionStore.logout()
-  router.push({ name: 'login' })
+const handleLogout = function() {
+  logoutRedirect()
 }
 
 </script>


### PR DESCRIPTION
Closes the last SSO-logout gap found in an audit of all three OIDC clients (ClientApp, ManagementFront, WebFront).

## The gap
`NoMapsetsModal`'s **"Uitloggen"** button called `sessionStore.logout()` — a **local-only** logout (clear tokens + `api.auth.signOut()`). That leaves the provider's SSO session alive, so the next `/authorize` silently re-signs-in the **same** user. Since this modal appears precisely when a logged-in user has *no accessible mapsets*, the button's whole purpose is to switch accounts — which it couldn't do.

## Fix
Use RP-initiated `logoutRedirect()` (→ `/oauth2/end-session?id_token_hint=…&post_logout_redirect_uri=…`), exactly like `UserMenu`. Drops the now-unused `useRouter`/`sessionStore` locals.

## Audit result (rest of the fleet)
- **UserMenu** logout in all three apps → already RP-initiated ✅
- ClientApp `/logout` route, ManagementFront 403 page → already RP ✅
- `App.vue` `store.logout()` calls are the 401/expiry handlers — intentionally a local clear (you want silent re-auth on a merely-expired access token, not a forced SSO logout) ✅
- DB: `enable_end_session=true` + post-logout URIs present for all three clients ✅

`pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)