### PR TITLE
chore: refresh stale docs and env declarations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,13 @@ No test framework is configured. Uses pnpm as package manager.
 
 ## Architecture
 
-FunderMaps is a Vue 3 + TypeScript + Vite application for building foundation/subsidence analysis with Mapbox map visualization. It uses `<script setup>` SFCs, Pinia for state management, and Tailwind CSS v4 for styling (via `@tailwindcss/vite` plugin, config in `src/style.css` `@theme` block). Custom CSS lives in `public/resources/styles/` using native CSS nesting.
+FunderMaps is a Vue 3 + TypeScript + Vite application for building foundation/subsidence analysis with Mapbox map visualization. It uses `<script setup>` SFCs, Pinia for state management, and Tailwind CSS v4 for styling (via `@tailwindcss/vite` plugin, config in `src/style.css` `@theme` block). Custom CSS lives in `src/styles/` (imported via `src/main.ts`) using native CSS nesting.
 
 ### Source Layout (`src/`)
 
 - **`router/`** - Vue Router config. Routes: `/login`, `/forgotten`, `/reset/:resetKey?`, `/` (home), `/map/:mapsetId`, `/map/:mapsetId/building/:buildingId(/:panel)`
 - **`store/`** - Pinia stores. Core: `session` (auth), `main` (UI state/modals), `buildings` (selected building), `mapsets` (available mapsets), `layers` (visibility, persisted to sessionStorage), `filters` (ownership), `metadata` (user prefs). Building-specific substores in `store/building/` (analysis, geolocations, incidents, inquiries, recovery, statistics, subsidence)
-- **`services/`** - API layer. `apiClient.ts` is the base HTTP client with JWT auth (Bearer token), auto-redirect on auth failure, and token refresh. Endpoint modules in `services/api/` (auth, building, mapset, metadata, org, pdf, userprofile)
+- **`services/`** - API layer. `apiClient.ts` is the base HTTP client; it attaches the opaque OIDC bearer, performs a single silent refresh on `401`, and redirects to login when that fails. OIDC PKCE flow in `oidc.ts`, token storage in `token.ts`. Endpoint modules in `services/api/` (auth, building, mapset, metadata, pdf, userprofile)
 - **`components/Mapbox/`** - Map integration. `Map.vue` is the main map component. Composables (`use*.ts`) handle layers, sources, events, markers, clustering, geo-fencing, ownership filters, position tracking, and administrative boundaries
 - **`config/layers/`** - JSON layer definitions for Mapbox styling (30+ files for foundation types, incidents, risk assessments, etc.)
 - **`datastructures/`** - TypeScript interfaces, enums, and data classes (Location, Controls, analysis/report types)
@@ -46,7 +46,7 @@ Required `VITE_` prefixed env vars (no `.env` file in repo):
 
 ### Authentication Flow
 
-JWT-based auth stored in localStorage as `access_token`. App.vue refreshes the token every 10 minutes. The `session` store handles login/logout and JWT claim extraction. `apiClient.ts` attaches the Bearer token to all requests. `VITE_AUTH_KEY` can override JWT with API key auth.
+**OIDC** authorization-code + PKCE (`client_id=webfront`), implemented in `services/oidc.ts`. The login form lives in the auth app (auth.fundermaps.com); `/login` redirects there and the callback exchanges the code for tokens. Tokens are **opaque** (not JWTs — see `services/token.ts`), stored in localStorage; there is no client-side decoding. A `refresh` token (via `offline_access`) drives a single silent refresh on `401` inside `apiClient.ts` — if that fails the session drops and the shell redirects to login. The `session` store handles `/me`, role flags, logout, and `logoutRedirect()` (RP-initiated end-session). The `/forgotten` and `/reset` routes still cover the local password-reset flow.
 
 ### Map Layer System
 
@@ -58,7 +58,6 @@ Mapsets define which layers are available. Layer configs in `config/layers/` def
 - **chart.js** + chartjs-plugin-trendline - Data visualization
 - **zod** - Schema validation
 - **vite-svg-loader** - Import SVGs as Vue components
-- **jwt-decode** - JWT token parsing
 
 ### Backend Context
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ pnpm format
 
 ## Architecture
 
-The application uses `<script setup>` single-file components, Pinia for state management, and Tailwind CSS v4 for styling. Authentication is JWT-based. Map layers and data sources are configured per mapset with geographic fencing.
+The application uses `<script setup>` single-file components, Pinia for state management, and Tailwind CSS v4 for styling. Authentication is OIDC (authorization-code + PKCE). Map layers and data sources are configured per mapset with geographic fencing.
 
 ### Source Layout
 
 - `src/router/` - Vue Router configuration
 - `src/store/` - Pinia stores (session, mapsets, layers, buildings, filters, metadata)
-- `src/services/` - API client with JWT auth and endpoint modules
+- `src/services/` - API client (OIDC bearer) and endpoint modules
 - `src/components/Mapbox/` - Map component and composables for layers, sources, events, clustering
 - `src/config/layers/` - Mapbox GL layer style definitions
 - `src/datastructures/` - TypeScript interfaces, enums, and data classes

--- a/env.d.ts
+++ b/env.d.ts
@@ -21,8 +21,8 @@ interface ImportMetaEnv {
   // Fundermaps base mapbox style
   readonly VITE_FUNDERMAPS_BASE_STYLE: string
 
-  // Fundermaps API Key
-  readonly VITE_AUTH_KEY: string
+  // Layer the building-number labels are inserted before (optional)
+  readonly VITE_FUNDERMAPS_NUMBER_LAYER: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Doc/hygiene pass — brings the docs in line with the shipped OIDC auth and v4 styling. No runtime code changes.

## Fixed
- **Auth description** (`CLAUDE.md` + `README.md`): was "JWT-based auth … App.vue refreshes the token every 10 minutes … JWT claim extraction … `VITE_AUTH_KEY` can override". None of that is true anymore — auth is **OIDC (authorization-code + PKCE)** with **opaque** tokens (`token.ts` replaced `jwt.ts`), a single silent refresh on `401` in `apiClient.ts`, and no 10-min timer. Rewrote accordingly.
- **`CLAUDE.md`**: custom CSS lives in `src/styles/` (not `public/resources/styles/`); removed the `org` endpoint module from the list (no `services/api/org.ts`); removed the **jwt-decode** "Key Libraries" entry (not a dependency, imported nowhere).
- **`env.d.ts`**: removed the dead `VITE_AUTH_KEY` declaration (referenced nowhere in `src/`), and added `VITE_FUNDERMAPS_NUMBER_LAYER` — `useMapLayers.ts` reads it but it was undeclared.
- Removed `src/assets/fonts/.gitkeep` — the directory holds real font files.

## Verification
- `pnpm build` (vue-tsc + vite) passes — confirms nothing referenced the removed `VITE_AUTH_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)