### PR TITLE
fix(ui): drop the hover drop-shadow on buttons

### DIFF
--- a/src/styles/components/button.css
+++ b/src/styles/components/button.css
@@ -3,11 +3,11 @@
 }
 
 .button--solid {
-  @apply bg-green-500 text-white hover:-translate-y-0.5 hover:bg-green-700 hover:shadow-hover disabled:bg-grey-400 disabled:hover:translate-y-0;
+  @apply bg-green-500 text-white hover:-translate-y-0.5 hover:bg-green-700 disabled:bg-grey-400 disabled:hover:translate-y-0;
 }
 
 .button--outline {
-  @apply border-current text-green-500 hover:-translate-y-0.5 hover:border-transparent hover:bg-green-700 hover:text-white hover:shadow-hover disabled:text-grey-400 disabled:hover:translate-y-0;
+  @apply border-current text-green-500 hover:-translate-y-0.5 hover:border-transparent hover:bg-green-700 hover:text-white disabled:text-grey-400 disabled:hover:translate-y-0;
 }
 
 .button--link {


### PR DESCRIPTION
## Summary

\`.button--solid\` and \`.button--outline\` paired a hover lift (\`-translate-y-0.5\`) with \`shadow-hover\` (\`0 10px 20px ... 0 4px 4px ...\`). The shadow reads as dated. Drop the \`hover:shadow-hover\` utility — keep the micro-lift, which still communicates "interactive" on its own.

First small step in folding more of the staff-app vocabulary into the maps app. The full Windmill-style DNA migration is parked until we scope it for the customer-facing surface separately.

## Diff
\`\`\`diff
 .button--solid {
-  @apply ... hover:bg-green-700 hover:shadow-hover disabled:bg-grey-400 ...
+  @apply ... hover:bg-green-700 disabled:bg-grey-400 ...
 }

 .button--outline {
-  @apply ... hover:text-white hover:shadow-hover disabled:text-grey-400 ...
+  @apply ... hover:text-white disabled:text-grey-400 ...
 }
\`\`\`

## Test plan
- [x] \`pnpm build\` — clean
- [ ] **Manual:** hover any primary/outline button on the maps app — micro-lift still fires; no heavy drop shadow underneath. \`.button--square\` (icon buttons) wasn't using \`shadow-hover\` and is unchanged. Dropdown shadows on UserMenu / SearchBar / LeftSideBar are scoped to those floating panels (not \`.button\` rules) and stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)