### PR TITLE
fix(ui): drop the hover drop-shadow on .link--outline pills

### DIFF
--- a/src/styles/components/link.css
+++ b/src/styles/components/link.css
@@ -7,14 +7,14 @@
 }
 
 .link--outline {
-  @apply rounded border border-grey-200 px-4 py-3 transition-all duration-150 hover:border-transparent hover:bg-white hover:shadow-hover;
+  @apply rounded border border-grey-200 px-4 py-3 transition-colors duration-150 hover:border-grey-400 hover:bg-grey-100;
 
   &.active {
-    @apply border-green-500 bg-white shadow-hover;
+    @apply border-green-500 bg-white;
   }
 
   &.disabled {
-    @apply cursor-not-allowed bg-grey-200 opacity-60 hover:border-grey-200 hover:shadow-none;
+    @apply cursor-not-allowed bg-grey-200 opacity-60 hover:border-grey-200;
   }
 
   &.loading {


### PR DESCRIPTION
## Summary

Follow-up to #241. The hover shadow you wanted gone wasn't on \`.button\` — it was on \`.link--outline\`, which is what renders the building-menu pills (**Pand**, **Locatie**, **Fundering**, **Funderingsrisico**) and the **Naar kaart selectie** back-link in the legend sidebar (\`<MenuLink>\` / \`<BackLink>\` both compose to \`.link link--outline\`).

Same fix shape:
\`\`\`diff
 .link--outline {
-  @apply ... transition-all ... hover:border-transparent hover:bg-white hover:shadow-hover;
+  @apply ... transition-colors ... hover:border-grey-400 hover:bg-grey-100;

   &.active {
-    @apply border-green-500 bg-white shadow-hover;
+    @apply border-green-500 bg-white;
   }

   &.disabled {
-    @apply cursor-not-allowed bg-grey-200 opacity-60 hover:border-grey-200 hover:shadow-none;
+    @apply cursor-not-allowed bg-grey-200 opacity-60 hover:border-grey-200;
   }
 }
\`\`\`

- **Hover:** border darkens to \`grey-400\` + soft \`bg-grey-100\` fill.
- **Active** (current panel): \`green-500\` border on white — enough to flag the current item without the floating-pill look.
- **Disabled:** unchanged; dropped the redundant \`hover:shadow-none\` override that was only there to suppress the now-removed shadow.
- \`transition-all\` → \`transition-colors\` (no other animated property left).

## Test plan
- [x] \`pnpm build\` — clean
- [ ] **Manual:** open a building → right sidebar shows the menu pills without drop shadows, hover gives the in-place tint, active panel pill shows green border. Left sidebar after entering a mapset → "Naar kaart selectie" back-link reads the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)