### PR TITLE
fix(ui): MenuLink hover visibility + flatten card + softer modal shadow

### DIFF
--- a/src/styles/components/card/base.css
+++ b/src/styles/components/card/base.css
@@ -5,5 +5,5 @@
 }
 
 .card {
-  @apply overflow-hidden rounded-lg bg-white shadow-card;
+  @apply overflow-hidden rounded-lg border border-grey-200 bg-white;
 }

--- a/src/styles/components/link.css
+++ b/src/styles/components/link.css
@@ -7,14 +7,14 @@
 }
 
 .link--outline {
-  @apply rounded border border-grey-200 px-4 py-3 transition-colors duration-150 hover:border-grey-400 hover:bg-grey-100;
+  @apply rounded border border-grey-200 px-4 py-3 transition-colors duration-150 hover:border-grey-400 hover:bg-white;
 
   &.active {
     @apply border-green-500 bg-white;
   }
 
   &.disabled {
-    @apply cursor-not-allowed bg-grey-200 opacity-60 hover:border-grey-200;
+    @apply cursor-not-allowed bg-grey-200 opacity-60 hover:border-grey-200 hover:bg-grey-200;
   }
 
   &.loading {

--- a/src/styles/components/panel/modal.css
+++ b/src/styles/components/panel/modal.css
@@ -2,7 +2,7 @@
   .panel {
     /* Padding/shadow match Common/Card.vue (used by the auth pages) so modals
        and the login card share the same visual language. */
-    @apply relative max-h-full w-full max-w-3xl space-y-6 rounded-lg bg-white p-8 shadow-card;
+    @apply relative max-h-full w-full max-w-3xl space-y-6 rounded-lg border border-grey-200 bg-white p-8 shadow-float;
 
     &[data-variant="narrow"] {
       @apply max-w-xl;


### PR DESCRIPTION
## Summary

Three small moves in the Grafana / Windmill / GitHub flat direction. Conservative — nothing visually shocking for the external customers using the map.

### 1. MenuLink hover regression
**Fixes:** building-menu pills (Pand / Locatie / Fundering / etc.) lost hover feedback after PR #242.

The panel they sit in is \`bg-grey-100\`, and PR #242 set hover to \`bg-grey-100\` — same colour as the panel, so the hover was invisible. Flip hover to \`bg-white\` (lighter than the panel = clean elevation cue against the grey backdrop). Border still darkens to \`grey-400\`. Active state stays distinct via the green-500 border + white bg.

### 2. \`.card\` flat
\`\`\`diff
-.card { @apply overflow-hidden rounded-lg bg-white shadow-card; }
+.card { @apply overflow-hidden rounded-lg border border-grey-200 bg-white; }
\`\`\`
Card-as-bounded-panel idiom — matches what the staff apps now use. The auth pages (login / forgotten / reset) all pass \`<Card shadow ...>\`, which re-applies \`shadow-card\` via the explicit prop, so those views are unchanged.

### 3. Modal shadow softer
\`\`\`diff
-@apply ... bg-white p-8 shadow-card;
+@apply ... border border-grey-200 bg-white p-8 shadow-float;
\`\`\`
Modals still float — that depth cue is load-bearing for an overlay — but \`shadow-card\` (heavy double-drop, \`0 10px 20px + 0 4px 4px\`) is replaced by the softer \`shadow-float\` (\`0 5px 15px rgb(44 45 60 / 0.2)\`) + a 1px border carries the bounding.

### Out of scope (deliberately)
- Dropdown panels (UserMenu, SearchBar suggestions, mapset info-tooltip) still use \`shadow-float\` — already soft, leaving alone.
- \`.button\` base shape (pill, `border-2`, `font-extrabold`) is unchanged — that's the staff-app vocabulary shift; bigger visual hit; separate scope.

## Test plan
- [x] \`pnpm build\` — clean
- [x] Dev server boots; root HTTP 200
- [ ] **Manual:**
  - Open a building → hover each menu pill (Pand / Locatie / etc.). Hover bg flips to white against the grey panel; clear feedback.
  - Same for **Naar kaart selectie** on the left sidebar after entering a mapset.
  - Open any \`.card\` consumer (currently only the auth pages, which keep their look via the \`shadow\` prop). Login / forgotten-password / reset-password cards still look the same.
  - Trigger a modal (e.g. \`NoMapsetsModal\`, statistics, recovery sample). Modal still reads as an overlay, but the shadow underneath is softer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)