### PR TITLE
fix(auth): recover from a failed SSO callback instead of looping

### DIFF
--- a/src/views/auth/Callback.vue
+++ b/src/views/auth/Callback.vue
@@ -2,7 +2,7 @@
 import { onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import { exchangeCode } from '@/services/oidc'
+import { exchangeCode, logoutRedirect } from '@/services/oidc'
 import { useSessionStore } from '@/store/session'
 
 const route = useRoute()
@@ -27,14 +27,24 @@ onMounted(async () => {
     error.value = true
   }
 })
+
+// End the SSO session at the provider, then return to the map for a fresh
+// sign-in. A plain link back to /login would silently re-authenticate via the
+// still-alive SSO session — straight back into the same wrong account and the
+// same error. RP-initiated logout breaks that loop. (See oidc.ts.)
+function signOut() {
+  logoutRedirect()
+}
 </script>
 
 <template>
   <!-- Neutral loading during the code exchange — not the login chrome. -->
-  <div class="grid min-h-screen place-content-center text-grey-700">
+  <div class="grid min-h-screen place-content-center text-center text-grey-700">
     <p v-if="error" class="text-sm">
-      Inloggen mislukt.
-      <RouterLink :to="{ name: 'login' }" class="text-green-700 underline">Opnieuw proberen</RouterLink>
+      Inloggen mislukt. Mogelijk heeft het actieve account geen toegang.
+      <button type="button" class="text-green-700 underline" @click="signOut">
+        Inloggen met een ander account
+      </button>
     </p>
     <p v-else class="text-sm">Bezig met inloggen…</p>
   </div>


### PR DESCRIPTION
Part of #990 (fleet-wide consistency with the ClientApp fix).

The OIDC callback error path showed "Inloggen mislukt" with an *Opnieuw proberen* link to `/login`. Because the SSO session is still alive, that link silently re-authenticates as the **same** account and loops straight back to the error.

**Fix:** the recovery action now does an RP logout (`logoutRedirect`), ending the SSO session so the user gets a real login prompt and can sign in with a different account. Message also clarified ("mogelijk heeft het actieve account geen toegang").

Type-checks clean. No backend/DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)