### PR TITLE
fix(search): pan + mark when opening a building by BAG number

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -14,7 +14,7 @@ import CloseIcon from '@assets/svg/icons/close.svg'
 import FundermapsIcon from './Common/Icons/FundermapsIcon.vue';
 
 import { getSuggestions, getLookup, getSuggestionsNearCoordinates } from '@/services/pdok'
-import { IPDOKSuggestion } from '@/datastructures/interfaces';
+import { IPDOKSuggestion, IGeoLocationData } from '@/datastructures/interfaces';
 
 import { useMainStore } from '@/store/main';
 import { useSessionStore } from '@/store/session';
@@ -53,26 +53,27 @@ watch(
     // No repeat please
     if (value === lastQuery.value) return
 
-    // TODO: We have more tests to do here
-    // Directly open a known buildingId
+    // Looks like a BAG identifier? Try to open the building directly.
+    // Covers a bare 16-digit BAG number (PAND or NUMMERAANDUIDING) and any
+    // NL.IMBAG.* form.
     if (
       (value.length === 16 && /^[0-9]+$/.test(value)) ||
-      (value.includes('BAG') || value.includes('bag'))
+      value.toUpperCase().includes('BAG')
     ) {
-      const buildingIdVerified = await verifyBuildingId(value)
-      if (buildingIdVerified) {
-        buildingRouting.navigateToBuilding(value)
+      const location = await lookupBuilding(value)
+      if (location) {
+        await openBuilding(location)
         return
       }
     }
-    
+
     await handleGetSuggestions(value)
 
     // no results and query string longer than 10 characters? Let's give the Fundermaps API a try
     if (suggestions.value.length === 0 && value.length > 10) {
-      const buildingIdVerified = await verifyBuildingId(value)
-      if (buildingIdVerified) {
-        buildingRouting.navigateToBuilding(value)
+      const location = await lookupBuilding(value)
+      if (location) {
+        await openBuilding(location)
         return
       }
     }
@@ -155,17 +156,51 @@ const onHover = function onHover(index: number) {
 }
 
 /**
- * Get the building Id from Fundermaps API
+ * Look up a building by any BAG identifier via the Fundermaps API.
+ * Returns the resolved location (canonical id, address, coordinates) or null
+ * when the identifier doesn't resolve to a known building.
  */
-const verifyBuildingId = async function verifyBuildingId(id: string) {
+const lookupBuilding = async function lookupBuilding(id: string): Promise<IGeoLocationData | null> {
   try {
-    if (! isAuthenticated.value) return false
+    if (! isAuthenticated.value) return null
 
-    await getLocationInformationByBuildingId(id)
-    return true
+    return await getLocationInformationByBuildingId(id)
   } catch {
-    return false
+    return null
   }
+}
+
+/**
+ * Open a building resolved from a BAG-number search: pan + drop a marker at
+ * its coordinates (the geocoder doesn't return coordinates on navigation, so
+ * we set them here at the source), reflect the resolved address in the search
+ * box, and navigate to the canonical building id.
+ */
+const openBuilding = async function openBuilding(location: IGeoLocationData) {
+  const { latitude, longitude } = location.building
+  const lngLat =
+    typeof latitude === 'number' && typeof longitude === 'number'
+      ? new mapboxgl.LngLat(longitude, latitude)
+      : null
+
+  // Drop the marker up front — it tracks mapMarkerLatLon independently of the
+  // route, so it's safe to set before navigating.
+  if (lngLat) mapMarkerLatLon.value = lngLat
+
+  // Show the resolved address in the box (when the building has one), and
+  // suppress a follow-up suggestion lookup for that value.
+  if (location.address.street) {
+    lastQuery.value = location.address.fullAddress
+    queryString.value = location.address.fullAddress
+  }
+
+  handleClose()
+
+  // Await navigation before setting mapCenterLatLon — the center change
+  // triggers a URL writeback in mapCenterRouting; doing it first would push
+  // the old route and cancel this navigation (mirrors handleSelectBuilding).
+  await buildingRouting.navigateToBuilding(location.building.externalId)
+  if (lngLat) mapCenterLatLon.value = lngLat
 }
 
 

--- a/src/datastructures/interfaces/api/Location/IBuilding.ts
+++ b/src/datastructures/interfaces/api/Location/IBuilding.ts
@@ -3,5 +3,11 @@ import { IGeoLocationModel } from "./IGeoLocationModel";
 export interface IBuilding extends IGeoLocationModel {
   builtYear?: string, // DateTime
   active: boolean,
-  neighborhoodId?: string
+  neighborhoodId?: string,
+  // Building footprint centroid (EPSG:4326). Used to pan the map / drop a
+  // marker when a building is opened from a BAG-number search — the geocoder
+  // no longer returns building coordinates anywhere else, and the residence
+  // point is null for most buildings.
+  latitude?: number,
+  longitude?: number
 }

--- a/src/services/api/_adapters.ts
+++ b/src/services/api/_adapters.ts
@@ -251,11 +251,21 @@ export const adaptGeoLocationData = (raw: unknown): IGeoLocationData => {
   const opt = <T>(idField: string, build: () => T): T | null =>
     r[idField] ? build() : null
 
+  // Prefer the residence point when present, else fall back to the building
+  // footprint centroid — the API returns both; residence is null for most
+  // buildings, the centroid is always present.
+  const num = (v: unknown): number | undefined =>
+    typeof v === 'number' ? v : undefined
+  const latitude = num(r.residence_lat) ?? num(r.building_lat)
+  const longitude = num(r.residence_lon) ?? num(r.building_lon)
+
   return {
     building: {
       id: (r.building_id as string) ?? '',
       externalId: (r.building_id as string) ?? '',
       neighborhoodId: (r.neighborhood_id as string) ?? null,
+      latitude,
+      longitude,
     },
     address: {
       id: (r.address_id as string) ?? '',


### PR DESCRIPTION
## Why

Closes part of Laixer/FunderMaps#986 — "the searchbar must support searching by BAG number." The BAG-direct path already resolved and opened the building, but the **map never panned and no marker dropped**. Since commit `b5e51b4` ("the TS API geocoder no longer returns building coordinates"), the map only pans when `mapCenterLatLon`/`mapMarkerLatLon` are set explicitly at the source. The PDOK address path was fixed to do that (from PDOK's `centroide_ll`); the direct-BAG path was never given a coordinate source, so it opened the panel but left the map where it was. It also navigated by the raw typed id and threw away the lookup result.

## What

- **Adapter / interface**: surface `building.latitude` / `building.longitude` on the geolocation data (residence point preferred, building centroid fallback — see the paired API PR Laixer/FunderMapsApi#71). Nothing else watches these fields, so the map-click flow is unaffected.
- **SearchBar**: the BAG-direct branch (`lookupBuilding` → `openBuilding`) now mirrors the working address path — drops a marker + pans from the resolved coordinates, reflects the resolved address in the search box, and navigates by the **canonical PAND id**. `mapCenterLatLon` is set only *after* `navigateToBuilding` resolves, because the center change triggers a URL writeback in `mapCenterRouting` that would otherwise push the old route and cancel the navigation (same ordering as `handleSelectBuilding`).
- Failed lookups return `null` and fall through to PDOK suggestions, unchanged.

## Verification (E2E on the guest)

- `vue-tsc --noEmit` clean; `pnpm build` green.
- Ran the **real adapter against the live local API** for a bare 16-digit PAND, a bare NUMMERAANDUIDING, the full `NL.IMBAG.PAND.*` form, and a bogus id:
  - addressed building → coords from the residence point, address relabel applied;
  - residence-less rural PAND → coords from the centroid, empty street so the box is left as typed (no `","` mislabel);
  - bogus id → API 400 → `null` → falls through to PDOK without crashing.

## Depends on

Laixer/FunderMapsApi#71 for the centroid fields. The adapter degrades gracefully against an un-upgraded API (falls back to residence coords, i.e. today's behavior), so there's no hard deploy ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)