### PR TITLE
Show inquiry download to any logged-in user + add Data-eigenaar field

### DIFF
--- a/src/components/Building/InquiryPanel.vue
+++ b/src/components/Building/InquiryPanel.vue
@@ -27,7 +27,7 @@ const inquiriesStore = useInquiriesStore()
 const { shownReportIndex, isSamplePanelOpen } = storeToRefs(inquiriesStore)
 const { buildingId } = storeToRefs(useBuildingStore())
 const { remarkPopoverTitle, remarkPopoverText, isRemarkPopoverOpen } = storeToRefs(useMainStore())
-const { isOrgAvailable } = useSessionStore()
+const { isAuthenticated } = storeToRefs(useSessionStore())
 
 /**
  * Props & events
@@ -104,6 +104,7 @@ const reportFieldsWithData = computed(() => {
       new FieldDataConfig({ name: 'documentDate' }),
       new FieldDataConfig({ name: 'contractorName', source: selectedCaseItem.value?.report.attribution }),
       new FieldDataConfig({ name: 'ownerName', source: selectedCaseItem.value?.report.attribution }),
+      new FieldDataConfig({ name: 'dataOwnerName', source: selectedCaseItem.value?.report.attribution }),
       new FieldDataConfig({ name: 'creatorName', source: selectedCaseItem.value?.report.attribution }),
       new FieldDataConfig({ name: 'reviewerName', source: selectedCaseItem.value?.report.attribution }),
       new FieldDataConfig({ name: 'auditStatus', source: selectedCaseItem.value?.report.state }),
@@ -142,8 +143,12 @@ const downloadDetails = computed(() => {
 
   let filename = selectedCaseItem.value?.report.documentName || 'Onderzoeksdocument'
 
-  // Only show the download button if the logged in user belongs to the org that owns the report
-  if (! isOrgAvailable(selectedCaseItem.value?.report?.attribution?.owner)) {
+  // Inquiry source files are downloadable by any logged-in user: the API
+  // serves them ownership-agnostically (#968), so hiding the button when the
+  // report's owning org differs from the user's only blocked access to data
+  // that was already reachable. Owner-org gating returns in the data-owner
+  // epic (#973) once attribution is corrected via data_owner_organization_id.
+  if (! isAuthenticated.value) {
     return null
   }
 

--- a/src/datastructures/fieldLabels.ts
+++ b/src/datastructures/fieldLabels.ts
@@ -68,6 +68,8 @@ export const AttributionControlFieldLabels = <Record<string, string>> {
   reviewer: "Gecontroleerd door",
   contractorName: "Uitvoerder",
   ownerName: "Opdrachtgever",
+  dataOwner: "Data-eigenaar",
+  dataOwnerName: "Data-eigenaar",
   creatorName: "Verwerkt door",
   reviewerName: "Gecontroleerd door"
 }

--- a/src/datastructures/interfaces/api/Controls/IAttributionControl.ts
+++ b/src/datastructures/interfaces/api/Controls/IAttributionControl.ts
@@ -8,6 +8,8 @@ export interface IAttributionControl extends IEnumMethods {
   creatorName: string
   owner: string, // uuid
   ownerName: string
+  dataOwner: string, // uuid — org that owns the data (#973)
+  dataOwnerName: string
   contractor: string // uuid
   contractorName: string
 }

--- a/src/services/api/_adapters.ts
+++ b/src/services/api/_adapters.ts
@@ -312,6 +312,10 @@ interface RawAttributedRow extends Record<string, unknown> {
   attribution_creator_name?: string | null
   attribution_owner?: string | null
   attribution_owner_name?: string | null
+  // Data owner (issue #973). Not yet served by the API — falls back to the
+  // owning org below until report.inquiry.data_owner_organization_id ships.
+  attribution_data_owner?: string | null
+  attribution_data_owner_name?: string | null
   attribution_contractor?: number | null
   attribution_contractor_name?: string | null
   audit_status?: string
@@ -329,6 +333,10 @@ const envelopes = (r: RawAttributedRow) => ({
     creatorName: r.attribution_creator_name ?? null,
     owner: r.attribution_owner ?? null,
     ownerName: r.attribution_owner_name ?? null,
+    // Data owner mirrors the owning org until the API exposes the real
+    // data_owner_organization_id field; repoint here when it does (#973).
+    dataOwner: r.attribution_data_owner ?? r.attribution_owner ?? null,
+    dataOwnerName: r.attribution_data_owner_name ?? r.attribution_owner_name ?? null,
     contractor: r.attribution_contractor ?? null,
     contractorName: r.attribution_contractor_name ?? null,
   },


### PR DESCRIPTION
## Context

Quick-win slice of **Laixer/FunderMaps#973** (data ownership), addressing the two concrete points Don raised in the issue comments. Also related: **Laixer/FunderMaps#968** (ownership-agnostic inquiry access — backend already shipped).

This is WebFront-only; no schema or API changes.

## What & why

### 1. Download button now shows for any logged-in user
The button in the *Onderzoeksinformatie* panel was gated on `isOrgAvailable(attribution.owner)` — you had to be a member of the report's owning org. Historical data sits under scattered legacy orgs, so this hid the button for almost everyone.

The API already serves `/api/inquiry/:id/download` **ownership-agnostically** (#968), so the gate only ever hid a file that was *already reachable*. **No new exposure** — this just aligns the UI with what the backend already allows. Now gated on `isAuthenticated`.

### 2. "Data-eigenaar" field added to the panel
Wired forward-compatibly through the adapter: reads `attribution_data_owner_name` when the API exposes it, otherwise **falls back to the owning org**. Today it shows the owning organisation (the de-facto data owner); once `report.inquiry.data_owner_organization_id` ships in the epic, the adapter auto-picks up the corrected value — no further frontend change needed.

## Heads-up — access-rule decision
This deliberately softens #973's "only the owning org may download" to #968's "any logged-in user." That choice is what actually unblocks Don now; proper owner-gating only becomes meaningful after the backfill corrects *who* the owner is, and belongs in the `data_owner_organization_id` epic. Code comments note this.

## Test
- `npx vue-tsc --noEmit` — clean.
- Not yet eyeballed live in `pnpm dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)