### PR TITLE
feat: serve analysis layers from the Martin tileserver

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -15,8 +15,11 @@ interface ImportMetaEnv {
   readonly VITE_DEFAULT_MAPSET_ID: string
   readonly VITE_DEFAULT_LAYERS: string
 
-  // Fundermaps Tile server 
+  // Fundermaps static tileset bucket (tippecanoe builds on Spaces)
   readonly VITE_FUNDERMAPS_TILES_URL: string
+
+  // Fundermaps dynamic tileserver (Martin) — serves the 'buildings' source
+  readonly VITE_FUNDERMAPS_TILESERVER_URL: string
 
   // Fundermaps base mapbox style
   readonly VITE_FUNDERMAPS_BASE_STYLE: string

--- a/src/components/Mapbox/useMapSources.ts
+++ b/src/components/Mapbox/useMapSources.ts
@@ -19,7 +19,7 @@ export const useMapSources = function useMapSources(
   }
 
   const sourceZoomLevels: Record<string, { min?: number, max?: number }> = {
-    'incident_neighboorhood': {
+    'incident_neighborhood': {
       min: 10
     },
     'incident_municipality': {
@@ -30,6 +30,10 @@ export const useMapSources = function useMapSources(
       min: 10
     }
   }
+
+  // Sources served dynamically by the Martin tileserver
+  // (VITE_FUNDERMAPS_TILESERVER_URL) instead of the static tileset bucket.
+  const dynamicSources = ['buildings']
 
   /**
    * Add a map source
@@ -49,7 +53,11 @@ export const useMapSources = function useMapSources(
       return
     }
 
-    const sourcePath = (import.meta.env.VITE_FUNDERMAPS_TILES_URL + '' || '')
+    const urlTemplate = dynamicSources.includes(sourceName)
+      ? import.meta.env.VITE_FUNDERMAPS_TILESERVER_URL
+      : import.meta.env.VITE_FUNDERMAPS_TILES_URL
+
+    const sourcePath = (urlTemplate + '' || '')
       .replace('{SOURCE}', sourceName || '')
 
     /**

--- a/src/config/layers/bio-infection-risk.json
+++ b/src/config/layers/bio-infection-risk.json
@@ -1,8 +1,8 @@
 {
   "id": "bio-infection-risk",
   "type": "fill-extrusion",
-  "source": "analysis_risk",
-  "source-layer": "analysis_risk",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "all",
       [

--- a/src/config/layers/construction-year.json
+++ b/src/config/layers/construction-year.json
@@ -1,8 +1,8 @@
 {
   "id": "construction-year",
   "type": "fill-extrusion",
-  "source": "analysis_building",
-  "source-layer": "analysis_building",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": ["has", "construction_year"],
   "layout": {"visibility": "none"},
   "paint": {

--- a/src/config/layers/damage-cause.json
+++ b/src/config/layers/damage-cause.json
@@ -1,8 +1,8 @@
 {
   "id": "damage-cause",
   "type": "fill-extrusion",
-  "source": "analysis_report",
-  "source-layer": "analysis_report",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "match",
       ["get", "damage_cause"],

--- a/src/config/layers/dewatering-depth-risk.json
+++ b/src/config/layers/dewatering-depth-risk.json
@@ -1,8 +1,8 @@
 {
   "id": "dewatering-depth-risk",
   "type": "fill-extrusion",
-  "source": "analysis_risk",
-  "source-layer": "analysis_risk",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "all",
       [

--- a/src/config/layers/drystand-risk.json
+++ b/src/config/layers/drystand-risk.json
@@ -1,8 +1,8 @@
 {
   "id": "drystand-risk",
   "type": "fill-extrusion",
-  "source": "analysis_risk",
-  "source-layer": "analysis_risk",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "all",
       [

--- a/src/config/layers/enforcement-term.json
+++ b/src/config/layers/enforcement-term.json
@@ -1,8 +1,8 @@
 {
   "id": "enforcement-term",
   "type": "fill-extrusion",
-  "source": "analysis_report",
-  "source-layer": "analysis_report",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": ["has", "enforcement_term"],
   "layout": {"visibility": "none"},
   "paint": {

--- a/src/config/layers/foundation-recovery.json
+++ b/src/config/layers/foundation-recovery.json
@@ -1,8 +1,8 @@
 {
   "id": "foundation-recovery",
   "type": "fill-extrusion",
-  "source": "analysis_foundation",
-  "source-layer": "analysis_foundation",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "all",
       [

--- a/src/config/layers/foundation-type-cluster.json
+++ b/src/config/layers/foundation-type-cluster.json
@@ -1,8 +1,8 @@
 {
   "id": "foundation-type-cluster",
   "type": "fill-extrusion",
-  "source": "analysis_foundation",
-  "source-layer": "analysis_foundation",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "all",
       [

--- a/src/config/layers/foundation-type-established.json
+++ b/src/config/layers/foundation-type-established.json
@@ -1,8 +1,8 @@
 {
   "id": "foundation-type-established",
   "type": "fill-extrusion",
-  "source": "analysis_foundation",
-  "source-layer": "analysis_foundation",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "all",
       [

--- a/src/config/layers/foundation-type-indicative.json
+++ b/src/config/layers/foundation-type-indicative.json
@@ -1,8 +1,8 @@
 {
   "id": "foundation-type-indicative",
   "type": "fill-extrusion",
-  "source": "analysis_foundation",
-  "source-layer": "analysis_foundation",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "all",
       [

--- a/src/config/layers/inquiry-type.json
+++ b/src/config/layers/inquiry-type.json
@@ -1,8 +1,8 @@
 {
   "id": "inquiry-type",
   "type": "fill-extrusion",
-  "source": "analysis_report",
-  "source-layer": "analysis_report",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "match",
       ["get", "inquiry_type"],

--- a/src/config/layers/monitoring.json
+++ b/src/config/layers/monitoring.json
@@ -1,8 +1,8 @@
 {
   "id": "monitoring",
   "type": "fill-extrusion",
-  "source": "analysis_monitoring",
-  "source-layer": "analysis_monitoring",
+  "source": "buildings",
+  "source-layer": "buildings",
   "layout": {"visibility": "none"},
   "paint": {
       "fill-extrusion-color": "#ce007c",

--- a/src/config/layers/overall-quality.json
+++ b/src/config/layers/overall-quality.json
@@ -1,8 +1,8 @@
 {
   "id": "overall-quality",
   "type": "fill-extrusion",
-  "source": "analysis_report",
-  "source-layer": "analysis_report",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": [
       "match",
       ["get", "overall_quality"],

--- a/src/config/layers/owner.json
+++ b/src/config/layers/owner.json
@@ -1,8 +1,8 @@
 {
   "id": "owner",
   "type": "fill-extrusion",
-  "source": "analysis_building",
-  "source-layer": "analysis_building",
+  "source": "buildings",
+  "source-layer": "buildings",
   "minzoom": 13,
   "filter": [
       "match",

--- a/src/config/layers/restoration-cost.json
+++ b/src/config/layers/restoration-cost.json
@@ -1,8 +1,8 @@
 {
   "id": "restoration-cost",
   "type": "fill-extrusion",
-  "source": "analysis_risk",
-  "source-layer": "analysis_risk",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": ["has", "restoration_costs"],
   "layout": {"visibility": "none"},
   "paint": {

--- a/src/config/layers/unclassified-risk.json
+++ b/src/config/layers/unclassified-risk.json
@@ -1,8 +1,8 @@
 {
   "id": "unclassified-risk",
   "type": "fill-extrusion",
-  "source": "analysis_risk",
-  "source-layer": "analysis_risk",
+  "source": "buildings",
+  "source-layer": "buildings",
   "minzoom": 13,
   "filter": [
       "all",

--- a/src/config/layers/velocity.json
+++ b/src/config/layers/velocity.json
@@ -1,8 +1,8 @@
 {
   "id": "velocity",
   "type": "fill-extrusion",
-  "source": "analysis_foundation",
-  "source-layer": "analysis_foundation",
+  "source": "buildings",
+  "source-layer": "buildings",
   "filter": ["has", "velocity"],
   "layout": {"visibility": "none"},
   "paint": {


### PR DESCRIPTION
Cutover approved by Yorick after eyeballing the Martin preview. All 17 `analysis_*` layer configs now use the single dynamic `buildings` source (source-layer `buildings`) from the Martin tileserver via new build-time env `VITE_FUNDERMAPS_TILESERVER_URL`. Static sources (`facade_scan`, `incident*`, `building_cluster`) untouched.

Also fixes the `incident_neighboorhood` typo key (min-zoom override never applied).

**Do not merge before** the maps-prod app spec carries `VITE_FUNDERMAPS_TILESERVER_URL` and tiles.fundermaps.com is live — deploy_on_push builds immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)