### PR TITLE
feat: contractor layer style (Rapportage mapset, #882)

### DIFF
--- a/src/config/layers/contractor.json
+++ b/src/config/layers/contractor.json
@@ -1,0 +1,40 @@
+{
+  "id": "contractor",
+  "type": "fill-extrusion",
+  "source": "buildings",
+  "source-layer": "buildings",
+  "filter": ["has", "contractor"],
+  "layout": {"visibility": "none"},
+  "paint": {
+      "fill-extrusion-height": ["get", "height"],
+      "fill-extrusion-color": [
+          "match",
+          ["get", "contractor"],
+          ["KCAF"],
+          "#85dbbe",
+          ["FunderMaps B.V."],
+          "#96ed51",
+          ["Gemeente Haarlem"],
+          "#b59e3c",
+          ["Gemeente Rotterdam"],
+          "#7edf9a",
+          ["Perfectkeur"],
+          "#bdf450",
+          ["Funderingsloket"],
+          "#9d592d",
+          ["Elkien"],
+          "#79e370",
+          ["Gemeente Dordrecht"],
+          "#d3e14d",
+          ["Wareco"],
+          "#8c3a28",
+          ["Gemeente Schiedam"],
+          "#7ee587",
+          ["VastgoedNED"],
+          "#c9b441",
+          ["Gemeente Zaanstad"],
+          "#7b2a2d",
+          "#6a6c70"
+      ]
+  }
+}


### PR DESCRIPTION
Companion to [FunderMapsWorker#55](https://github.com/Laixer/FunderMapsWorker/pull/55) for [Laixer/FunderMaps#882](https://github.com/Laixer/FunderMaps/issues/882).

New `config/layers/contractor.json` — fill-extrusion over the dynamic `buildings` source, `["has", "contractor"]` filter (only researched buildings paint), match-by-name colors for the top-12 contractors (Legenda-default design tokens, same assignment as the `mapset_layer` legend row), grey `#6a6c70` fallback for Overig. Names match `application.contractor.name` exactly — same convention (and same rename-risk) as the existing `owner` layer.

No registration needed: layer configs are dynamically imported by id, and the layer id comes from the mapset's DB config once the Worker migrate script runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)