### PR TITLE
feat: load building_cluster source from the Martin tileserver

### DIFF
--- a/src/components/Mapbox/useMapSources.ts
+++ b/src/components/Mapbox/useMapSources.ts
@@ -35,7 +35,7 @@ export const useMapSources = function useMapSources(
   // (VITE_FUNDERMAPS_TILESERVER_URL) instead of the static tileset bucket.
   // These are added via their TileJSON endpoint, so tile URLs, zoom range
   // and bounds come from the server instead of being duplicated here.
-  const dynamicSources = ['buildings']
+  const dynamicSources = ['buildings', 'building_cluster']
 
   /**
    * TileJSON endpoint for a dynamic source. Accepts both a bare base


### PR DESCRIPTION
Moves the `building_cluster` source ("Bouwkundige eenheid" layer on the Pand mapset) from the static Spaces tileset — frozen since **September 2024** — to the Martin tileserver, by adding it to `dynamicSources` in `useMapSources.ts`. Tile URLs, zoom range and bounds now come from the TileJSON endpoint.

Backend counterpart: FunderMapsWorker `450fee8` (flat `maplayer.building_cluster_tiles` table + `maplayer.building_cluster(z,x,y)` function source, nightly refresh step in the Windmill flow). MVT layer name matches the old tileset, so `config/layers/building-cluster.json` is untouched.

Do not merge before the Martin deployment picks up the new function source (verified via TileJSON + tile fetch on tiles.fundermaps.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)