### PR TITLE
Allow OpenFreeMap tiles in the CSP; refresh preconnects

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       style-src 'self' 'unsafe-inline';
       img-src 'self' data: blob: https:;
       font-src 'self';
-      connect-src 'self' https://*.mapbox.com https://api.pdok.nl https://*.fundermaps.com https://*.digitaloceanspaces.com https://*.amazonaws.com https://fundermaps-api-test-grcaa.ondigitalocean.app;
+      connect-src 'self' https://tiles.openfreemap.org https://api.pdok.nl https://*.fundermaps.com https://*.digitaloceanspaces.com https://*.amazonaws.com https://fundermaps-api-test-grcaa.ondigitalocean.app;
       worker-src 'self' blob:;
       child-src blob:;
       base-uri 'self';
@@ -35,8 +35,9 @@
     " />
 
     <!-- Preconnect to external services -->
-    <link rel="preconnect" href="https://api.mapbox.com" />
-    <link rel="preconnect" href="https://events.mapbox.com" />
+    <link rel="preconnect" href="https://tiles.openfreemap.org" />
+    <link rel="preconnect" href="https://tiles.fundermaps.com" />
+    <link rel="preconnect" href="https://fundermaps-tileset.ams3.digitaloceanspaces.com" />
 
     <!-- Build version -->
     <meta name="version" content="%VITE_GIT_COMMIT_HASH%" />


### PR DESCRIPTION
Follow-up to #273: `connect-src` never allowed `tiles.openfreemap.org`, so the swapped basemap rendered blank (our boundaries/fonts passed via the `*.fundermaps.com` / `*.digitaloceanspaces.com` wildcards). Mapbox domains and preconnects removed; preconnects now warm the three tile/asset hosts actually used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)