### PR TITLE
Per-build asset filenames; maplibre chunk grouping

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,15 @@ export default defineConfig(() => {
     process.env.VITE_GIT_COMMIT_HASH = 'unknown'
   }
 
+  // Unique per build: hashed filenames are content-based, so consecutive
+  // deploys reuse URLs for unchanged chunks. During a deploy transition the
+  // static host's SPA catch-all can answer a not-yet/no-longer-existing
+  // chunk URL with index.html, and the CDN edge then caches that HTML under
+  // the .js URL (s-maxage=86400) - poisoning the URL for a day. A build id
+  // in every filename makes each deploy's URLs fresh, so a poisoned entry
+  // is never requested again.
+  const buildId = Date.now().toString(36)
+
   return {
     plugins: [tailwindcss(), vue(), svgLoader()],
     resolve: {
@@ -21,18 +30,21 @@ export default defineConfig(() => {
       ],
     },
     build: {
-      // mapbox-gl is the floor of the bundle (~1.7MB minified, ~470kB
-      // gzipped) and already lives in its own chunk via manualChunks
-      // below. Raise the warning so the build output isn't noisy; other
-      // chunks all sit comfortably below.
+      // maplibre-gl is the floor of the bundle (~1.5MB minified) and
+      // lives in its own chunk via manualChunks below. Raise the warning
+      // so the build output isn't noisy; other chunks all sit comfortably
+      // below.
       chunkSizeWarningLimit: 1800,
       rollupOptions: {
         output: {
+          entryFileNames: `assets/[name]-[hash]-${buildId}.js`,
+          chunkFileNames: `assets/[name]-[hash]-${buildId}.js`,
+          assetFileNames: `assets/[name]-[hash]-${buildId}[extname]`,
           // Vite 8 (rolldown) requires manualChunks as a function, not an
           // object. Group third-party deps into named chunks to keep the
           // initial bundle small.
           manualChunks(id: string) {
-            if (id.includes('mapbox-gl')) return 'mapbox-gl'
+            if (id.includes('maplibre-gl')) return 'maplibre-gl'
             if (id.includes('chart.js') || id.includes('chartjs-plugin-trendline')) return 'chart'
             if (id.includes('vue-markdown-render')) return 'markdown'
           },


### PR DESCRIPTION
Fixes the module-MIME breakage class: during deploy transitions the static catch-all + edge caching (`s-maxage=86400`) can poison a chunk URL with HTML per colo for a day; content-based hashes keep those URLs hot across deploys. A per-build id in every asset filename makes each deploy's URLs fresh.

Also restores the dedicated map-library chunk (`manualChunks` still matched `mapbox-gl`, dead since #273).

🤖 Generated with [Claude Code](https://claude.com/claude-code)