### PR TITLE
Default basemap style URL via Martin (Chrome LNA blocks Spaces)

### DIFF
--- a/src/components/Mapbox/Map.vue
+++ b/src/components/Mapbox/Map.vue
@@ -52,7 +52,7 @@ const { maybeNudge: maybeNudgeLeft } = useMapboxControlNudge('left', 336, isLeft
 const options = computed(() => {
   const lastKnownPositioning = getLastKnownPositioning()
   return {
-    style: (import.meta.env.VITE_FUNDERMAPS_BASE_STYLE || 'https://fundermaps-tileset.ams3.digitaloceanspaces.com/assets/styles/fundermaps-basemap.json'),
+    style: (import.meta.env.VITE_FUNDERMAPS_BASE_STYLE || 'https://tiles.fundermaps.com/style/fundermaps-basemap'),
     center: getLatLngFromQueryString() || lastKnownPositioning.center || [4.897070, 52.377956], // [5.2913, 52.1326],
     zoom: lastKnownPositioning.zoom || 15,
     pitch: lastKnownPositioning.pitch || 30,

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -9,7 +9,7 @@ const router = useRouter()
 import MapBox from '@/components/Common/Mapbox/MapBox.vue';
 
 const options = {
-  style: 'https://fundermaps-tileset.ams3.digitaloceanspaces.com/assets/styles/fundermaps-basemap.json',
+  style: 'https://tiles.fundermaps.com/style/fundermaps-basemap',
   center: [4.503663, 52.530826],
   zoom: 15,
   pitch: 45,


### PR DESCRIPTION
Chrome's Local Network Access blocks browser fetches to `*.digitaloceanspaces.com` from public origins (see Laixer/FunderMapsWorker#58). Style now comes from `tiles.fundermaps.com/style/fundermaps-basemap`; the spec env override is already updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)