### PR TITLE
Emit and register the maplibre worker as a build asset

### DIFF
--- a/src/components/Common/Mapbox/MapBox.vue
+++ b/src/components/Common/Mapbox/MapBox.vue
@@ -8,9 +8,17 @@
  */
 
 import { onMounted, onUnmounted, provide, readonly, ref } from 'vue'
-import { Map as MaplibreMap } from 'maplibre-gl'
+import { Map as MaplibreMap, setWorkerUrl } from 'maplibre-gl'
+// maplibre v6 loads its worker as a sibling module via a runtime-computed
+// URL, which the bundler can't see - the file never gets emitted and the
+// request falls through to the SPA catch-all (text/html -> dead worker,
+// blank map). ?worker&url makes Vite bundle the worker with its imports
+// and hands us the hashed URL to register instead.
+import maplibreWorkerUrl from 'maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url'
 
 import 'maplibre-gl/dist/maplibre-gl.css';
+
+setWorkerUrl(maplibreWorkerUrl)
 
 /**
  * The MapLibre instance

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,15 @@ export default defineConfig(() => {
 
   return {
     plugins: [tailwindcss(), vue(), svgLoader()],
+    worker: {
+      rollupOptions: {
+        output: {
+          entryFileNames: `assets/[name]-[hash]-${buildId}.js`,
+          chunkFileNames: `assets/[name]-[hash]-${buildId}.js`,
+          assetFileNames: `assets/[name]-[hash]-${buildId}[extname]`,
+        },
+      },
+    },
     resolve: {
       alias: [
         { find: '@', replacement: fileURLToPath(new URL('./src', import.meta.url)) },


### PR DESCRIPTION
The actual root cause of the blank map since #273: maplibre v6 resolves its **worker** as a sibling module at runtime (`new URL('./maplibre-gl-worker.mjs', import.meta.url)`), which the bundler can't statically see — the file was never emitted, the request fell through to the SPA catch-all as `text/html`, and the module worker died ⇒ blank map for every authenticated user.

Fix: `?worker&url` import (Vite bundles worker + deps, hashed URL) + `setWorkerUrl()`. Verified end-to-end locally with a headless probe of the 404-page map (the only unauthenticated route that mounts a map): worker served as JS, map renders.

Reproduced on prod first: `GET /assets/maplibre-gl-worker.mjs → 200 text/html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)