### PR TITLE
Resolve the data-layer anchor against the running style

### DIFF
--- a/src/components/Mapbox/useMapLayers.ts
+++ b/src/components/Mapbox/useMapLayers.ts
@@ -92,7 +92,20 @@ export const useMapLayers = function useMapLayers(
           // Add ownership fencing
           applyOwnershipFilterToLayerSpecification(layerSpecification)
 
-          mapInstance.value.addLayer(layerSpecification, import.meta.env.VITE_FUNDERMAPS_NUMBER_LAYER || 'building-number-label-hover')
+          // Insert data layers below the purple admin-boundary lines (and
+          // thus below all labels). The anchor is resolved against the
+          // running style: the env override first, then the boundary
+          // layer, then the first symbol layer, then simply on top -
+          // a missing anchor id must never take the whole mapset down
+          // (the legacy hardcoded 'building-number-label-hover' anchor
+          // did exactly that after the basemap swap).
+          const anchorCandidates = [
+            import.meta.env.VITE_FUNDERMAPS_NUMBER_LAYER,
+            'fundermaps-municipality',
+          ].filter(Boolean) as string[]
+          const anchor = anchorCandidates.find((id) => mapInstance.value?.getLayer(id))
+            || mapInstance.value.getStyle().layers.find((l) => l.type === 'symbol')?.id
+          mapInstance.value.addLayer(layerSpecification, anchor)
 
           attachEventHandlers(layerId)
 


### PR DESCRIPTION
Follow-up to #273/#277: data layers were inserted `before: 'building-number-label-hover'` — a layer id that only existed in the legacy Mapbox Studio style. After the basemap swap every `addLayer` threw ("Cannot add layer … before non-existing layer") and no data layers rendered. The anchor now resolves at runtime: `VITE_FUNDERMAPS_NUMBER_LAYER` if set and present, else the purple boundary lines, else the first symbol layer, else top-of-stack.

Data layers land below boundaries and labels — text stays readable over extrusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)