### PR TITLE
feat(map): serve facade_scan and incident layers from the tileserver

### DIFF
--- a/src/components/Mapbox/useMapSources.ts
+++ b/src/components/Mapbox/useMapSources.ts
@@ -35,7 +35,21 @@ export const useMapSources = function useMapSources(
   // (VITE_FUNDERMAPS_TILESERVER_URL) instead of the static tileset bucket.
   // These are added via their TileJSON endpoint, so tile URLs, zoom range
   // and bounds come from the server instead of being duplicated here.
-  const dynamicSources = ['buildings', 'building_cluster']
+  //
+  // This is now every source the layer configs reference, so the static
+  // branch below is only reachable as a rollback (drop a name from this
+  // list and it goes back to Spaces). Once the cutover has held, the
+  // static path and VITE_FUNDERMAPS_TILES_URL can be removed outright —
+  // deliberately kept for now so a rollback needs no redeploy of logic.
+  const dynamicSources = [
+    'buildings',
+    'building_cluster',
+    'facade_scan',
+    'incident',
+    'incident_district',
+    'incident_municipality',
+    'incident_neighborhood',
+  ]
 
   /**
    * TileJSON endpoint for a dynamic source. Accepts both a bare base


### PR DESCRIPTION
Adds the five remaining static sources to `dynamicSources` so they are added via their TileJSON endpoint on tiles.fundermaps.com instead of the raw Spaces bucket.

Backed by Laixer/FunderMapsWorker#73 (`create_facade_scan_tiles.sql`, `create_incident_tiles.sql`), which moves `facade_scan` and the four incident tilesets off the nightly tippecanoe build — ~40 of the ~50 minutes `process_mapset` spends every night, for 8,774 features.

## No layer config changes

The MVT layer names match the retired tileset names, and every config already uses `source == source-layer == tileset name`. All ten affected configs (`facade-*`, `skewed-*`, `incident*`) are untouched.

## Rollback

This is now every source the configs reference, so the static branch below is only reachable as a rollback. It — and the `sourceZoomLevels` overrides it needs — are deliberately kept, so rolling back is one name off the list rather than a logic redeploy. Both can go once the cutover has held.

## Behaviour change

The incident sources now carry `municipality_id` / `district_id` / `neighborhood_id`, which the static tiles never had. The geofence in `useGeographyFilter.ts` builds `any(match(<id>, fence), !has(<id>))`, so features missing the id were always shown.

On **`Schiedam publiek`** — public, fenced to `GM0606` via the client-side override in `store/mapsets.ts`, and it includes the incident layer — that takes the layer from **all 2,728 Dutch incidents down to Schiedam's 216**. See the Worker PR for the full write-up.

## Verification

`vue-tsc --noEmit` and `eslint` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
