### PR TITLE
chore(map): drop the dead static tile path

### DIFF
--- a/src/components/Mapbox/useMapSources.ts
+++ b/src/components/Mapbox/useMapSources.ts
@@ -13,48 +13,10 @@ export const useMapSources = function useMapSources(
 
   const currentSources: string[] = []
 
-  const defaultMinMaxZoomLevels = {
-    min: 12,
-    max: 16
-  }
-
-  const sourceZoomLevels: Record<string, { min?: number, max?: number }> = {
-    'incident_neighborhood': {
-      min: 10
-    },
-    'incident_municipality': {
-      min: 7,
-      max: 11
-    },
-    'incident_district': {
-      min: 10
-    }
-  }
-
-  // Sources served dynamically by the Martin tileserver
-  // (VITE_FUNDERMAPS_TILESERVER_URL) instead of the static tileset bucket.
-  // These are added via their TileJSON endpoint, so tile URLs, zoom range
-  // and bounds come from the server instead of being duplicated here.
-  //
-  // This is now every source the layer configs reference, so the static
-  // branch below is only reachable as a rollback (drop a name from this
-  // list and it goes back to Spaces). Once the cutover has held, the
-  // static path and VITE_FUNDERMAPS_TILES_URL can be removed outright —
-  // deliberately kept for now so a rollback needs no redeploy of logic.
-  const dynamicSources = [
-    'buildings',
-    'building_cluster',
-    'facade_scan',
-    'incident',
-    'incident_district',
-    'incident_municipality',
-    'incident_neighborhood',
-  ]
-
   /**
-   * TileJSON endpoint for a dynamic source. Accepts both a bare base
-   * template ("https://tiles.example/{SOURCE}") and the tile-URL form
-   * ("https://tiles.example/{SOURCE}/{z}/{x}/{y}") in the env var.
+   * TileJSON endpoint for a source on the Martin tileserver. Accepts both a
+   * bare base template ("https://tiles.example/{SOURCE}") and the tile-URL
+   * form ("https://tiles.example/{SOURCE}/{z}/{x}/{y}") in the env var.
    */
   const tileJsonPath = function tileJsonPath(sourceName: string): string {
     return (import.meta.env.VITE_FUNDERMAPS_TILESERVER_URL + '' || '')
@@ -63,7 +25,13 @@ export const useMapSources = function useMapSources(
   }
 
   /**
-   * Add a map source
+   * Add a map source.
+   *
+   * Every source is served by the Martin tileserver and added via its
+   * TileJSON endpoint, so tile URLs, min/max zoom and bounds come from the
+   * server rather than being duplicated here. The static Spaces path that
+   * used to live alongside this is gone: the tiles it read were deleted from
+   * fundermaps-tileset on 2026-08-07, so it could only have produced 404s.
    */
   const addSource = function addSource(sourceName: string) {
     if (currentSources.includes(sourceName)) {
@@ -80,36 +48,11 @@ export const useMapSources = function useMapSources(
       return
     }
 
-    if (dynamicSources.includes(sourceName)) {
-      // Tile URLs, min/max zoom and bounds all come from the TileJSON.
-      mapInstance.value.addSource(
-        sourceName,
-        {
-          type: 'vector',
-          url: tileJsonPath(sourceName)
-        }
-      )
-
-      currentSources.push(sourceName)
-      return
-    }
-
-    const sourcePath = (import.meta.env.VITE_FUNDERMAPS_TILES_URL + '' || '')
-      .replace('{SOURCE}', sourceName || '')
-
-    /**
-     * Use source specific or default min / max zoom
-     */
-    const minzoom = sourceZoomLevels?.[sourceName]?.min || defaultMinMaxZoomLevels.min
-    const maxzoom = sourceZoomLevels?.[sourceName]?.max || defaultMinMaxZoomLevels.max
-
     mapInstance.value.addSource(
       sourceName,
       {
         type: 'vector',
-        tiles: [sourcePath],
-        minzoom,
-        maxzoom
+        url: tileJsonPath(sourceName)
       }
     )
 


### PR DESCRIPTION
Follow-up to #290. The static tiles that fallback branch read were deleted from `fundermaps-tileset` today — 231,641 objects across `facade_scan/` and the four `incident*` prefixes — so it could only ever produce 404s now.

It is also no longer a rollback path: rolling back means re-enabling the bundles and regenerating the tiles (~40 min), not dropping a name from an array here. Keeping dead code that points at deleted objects is worse than removing it.

Removes:
- the `dynamicSources` allowlist (every source is dynamic now)
- the static Spaces branch
- the `sourceZoomLevels` / `defaultMinMaxZoomLevels` overrides it needed — zoom range and bounds come from the TileJSON
- the last read of `VITE_FUNDERMAPS_TILES_URL`, which now has **no reference left anywhere in the repo** and can be dropped from the maps-prod env

Net 11 insertions, 68 deletions. `vue-tsc --noEmit` and `eslint` both clean.

## Not merged yet on purpose

Merging deploys maps-prod, and the `buildings` layer had a ~5 minute failure window this morning (09:22–09:27 UTC, statement timeouts on `maplayer.building_tiles`, since recovered). That is unrelated to this change — `buildings` has been Martin-served since July and never touched the static tiles — but I would rather not stack a deploy on top of it without a nod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
